### PR TITLE
Pull request 316 from njh/easyrdf

### DIFF
--- a/lib/RdfNamespace.php
+++ b/lib/RdfNamespace.php
@@ -340,8 +340,8 @@ class RdfNamespace
 
             $local_part = substr($uri, strlen($long));
 
-            if (strpos($local_part, '/') !== false) {
-                // we can't have '/' in local part
+            // check that local part only contains valid QName characters
+            if (!self::isValidXMLUriPart($local_part)) {
                 continue;
             }
 
@@ -428,5 +428,36 @@ class RdfNamespace
         }
 
         return $shortUri;
+    }
+
+    /**
+     * Check if a local or prefix portion of URI is valid XML
+     * 
+     * This check is based on the XML specification
+     * 
+     * prefix        ::= Name minus ":"                   // see: http://www.w3.org/TR/REC-xml-names/#NT-NCName
+     * Name          ::= NameStartChar (NameChar)*        // see: http://www.w3.org/TR/REC-xml/#NT-Name
+     * NameStartChar ::= ":" | [A-Z] | "_" | [a-z] | [#xC0-#xD6] | [#xD8-#xF6] | [#xF8-#x2FF] | [#x370-#x37D] |
+     *                   [#x37F-#x1FFF] | [#x200C-#x200D] | [#x2070-#x218F] | [#x2C00-#x2FEF] |
+     *                   [#x3001-#xD7FF] | [#xF900-#xFDCF] | [#xFDF0-#xFFFD] | [#x10000-#xEFFFF]
+     * NameChar      ::= NameStartChar | "-" | "." | [0-9] | #xB7 | [#x0300-#x036F] | [#x203F-#x2040]
+     *
+     * @param string $uri
+     * @return boolean
+     */
+    public static function isValidXMLUriPart(string $uri)
+    {
+        $_name_start_char = 
+            'A-Z_a-z\x{C0}-\x{D6}\x{D8}-\x{F6}\x{F8}-\x{2FF}\x{370}-\x{37D}\x{37F}-\x{1FFF}' .
+            '\x{200C}-\x{200D}\x{2070}-\x{218F}\x{2C00}-\x{2FEF}\x{3001}-\x{D7FF}\x{F900}-\x{FDCF}' . 
+            '\x{FDF0}-\x{FFFD}\x{10000}-\x{EFFFF}';
+        
+        $_namechar = 
+            $_name_start_char .
+            '\-\.0-9\x{B7}\x{0300}-\x{036F}\x{203F}-\x{2040}';
+
+        $regex = "/^[$_name_start_char][$_namechar]*\$/u";
+
+        return (bool) preg_match($regex, $uri);
     }
 }


### PR DESCRIPTION
Source: https://github.com/njh/easyrdf/pull/316

Hi @shawnhind i merged in your pull request you made at njh/easyrdf. *Because this repository is not actively maintained anymore, i decided to create this fork. For more info look [here](https://github.com/sweetyrdf/easyrdf#why-this-fork).*

Back to your pull request: unfortunately, some tests fail: https://travis-ci.com/github/sweetyrdf/easyrdf/jobs/331832731#L480

I think your method doesn't allow certain valid shorten-cases, for instance the following turtle code:

```turtle
<http://example.com/id/1> <http://www.w3.org/2000/01/rdf-schema#type> <http://example.com/ns/animals/dog> .
<http://example.com/id/2> <http://www.w3.org/2000/01/rdf-schema#type> <http://example.com/ns/animals/cat> .
<http://example.com/id/3> <http://www.w3.org/2000/01/rdf-schema#type> <http://example.com/ns/animals/bird> .
<http://example.com/id/4> <http://www.w3.org/2000/01/rdf-schema#type> <http://example.com/ns/animals/reptiles/snake> .
```

should be serialized to:

```turtle
@prefix id: <http://example.com/id/> .
@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@prefix animals: <http://example.com/ns/animals/> .

id:1 rdfs:type animals:dog .
id:2 rdfs:type animals:cat .
id:3 rdfs:type animals:bird .
id:4 rdfs:type <http://example.com/ns/animals/reptiles/snake> .
```

It would be great if you could look into it again and help me to merge in your code. Thank you in advance.