### PR TITLE
ntriples and turtle parser and serialised fixes

### DIFF
--- a/lib/Serialiser/Ntriples.php
+++ b/lib/Serialiser/Ntriples.php
@@ -56,11 +56,52 @@ class Ntriples extends Serialiser
      * Characters forbidden in n-triples literals according to
      * https://www.w3.org/TR/n-triples/#grammar-production-IRIREF
      * 
-     * Initialized by the first escapeIri() method call.
-     * 
      * @var string[]
      */
-    static private $iriEscapeMap;
+    static private $iriEscapeMap = array(
+        "<" => "\\u003C",
+        ">" => "\\u003E",
+        '"' => "\\u0022",
+        "{" => "\\u007B",
+        "}" => "\\u007D",
+        "|" => "\\u007C",
+        "^" => "\\u005E",
+        "`" => "\\u0060",
+        "\\" => "\\u005C",
+        "\x00" => "\\u0030",
+        "\x01" => "\\u0031",
+        "\x02" => "\\u0032",
+        "\x03" => "\\u0033",
+        "\x04" => "\\u0034",
+        "\x05" => "\\u0035",
+        "\x06" => "\\u0036",
+        "\x07" => "\\u0037",
+        "\x08" => "\\u0038",
+        "\x09" => "\\u0039",
+        "\x0A" => "\\u0031",
+        "\x0B" => "\\u0031",
+        "\x0C" => "\\u0031",
+        "\x0D" => "\\u0031",
+        "\x0E" => "\\u0031",
+        "\x0F" => "\\u0031",
+        "\x10" => "\\u0031",
+        "\x11" => "\\u0031",
+        "\x12" => "\\u0031",
+        "\x13" => "\\u0031",
+        "\x14" => "\\u0032",
+        "\x15" => "\\u0032",
+        "\x16" => "\\u0032",
+        "\x17" => "\\u0032",
+        "\x18" => "\\u0032",
+        "\x19" => "\\u0032",
+        "\x1A" => "\\u0032",
+        "\x1B" => "\\u0032",
+        "\x1C" => "\\u0032",
+        "\x1D" => "\\u0032",
+        "\x1E" => "\\u0033",
+        "\x1F" => "\\u0033",
+        "\x20" => "\\u0033"
+    );
 
     /**
      * Characters forbidden in n-triples literals according to
@@ -81,17 +122,6 @@ class Ntriples extends Serialiser
 
     public static function escapeIri($str)
     {
-        if (self::$iriEscapeMap === null) {
-            // the only forbidden characters according to 
-            // https://www.w3.org/TR/n-triples/#grammar-production-IRIREF
-            self::$iriEscapeMap = array();
-            foreach (array('<', '>', '"', '{', '}', '|', '^', '`', '\\') as $i) {
-                self::$iriEscapeMap[$i] = sprintf('\\u%04X', ord($i));
-            }
-            for ($i = 0; $i <= 32; $i++) {
-                self::$iriEscapeMap[chr($i)] = sprintf('\\u%04X', ord($i));
-            }
-        }
         return strtr($str, self::$iriEscapeMap);
     }
 

--- a/lib/Serialiser/Ntriples.php
+++ b/lib/Serialiser/Ntriples.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EasyRdf\Serialiser;
 
 /**
@@ -7,6 +8,7 @@ namespace EasyRdf\Serialiser;
  * LICENSE
  *
  * Copyright (c) 2009-2013 Nicholas J Humfrey.  All rights reserved.
+ * Copyright (c) 2020 Austrian Centre for Digital Humanities.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -41,7 +43,7 @@ use EasyRdf\Serialiser;
 
 /**
  * Class to serialise an EasyRdf\Graph to N-Triples
- * with no external dependencies.
+ * with no external dependancies.
  *
  * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
@@ -49,96 +51,48 @@ use EasyRdf\Serialiser;
  */
 class Ntriples extends Serialiser
 {
-    private $escChars = array();   // Character encoding cache
 
     /**
-     * @ignore
+     * Characters forbidden in n-triples literals according to
+     * https://www.w3.org/TR/n-triples/#grammar-production-IRIREF
+     * 
+     * Initialized by the first escapeIri() method call.
+     * 
+     * @var string[]
      */
-    protected function escapeString($str)
+    static private $iriEscapeMap;
+
+    /**
+     * Characters forbidden in n-triples literals according to
+     * https://www.w3.org/TR/n-triples/#grammar-production-STRING_LITERAL_QUOTE
+     * @var string[]
+     */
+    static private $literalEscapeMap = array(
+        "\n" => '\\n',
+        "\r" => '\\r',
+        '"' => '\\"',
+        '\\' => '\\\\'
+    );
+
+    public static function escapeLiteral($str)
     {
-        $result = '';
-        $strLen = mb_strlen($str, "UTF-8");
+        return strtr($str, self::$literalEscapeMap);
+    }
 
-        for ($i = 0; $i < $strLen; $i++) {
-            $c = mb_substr($str, $i, 1, "UTF-8");
-
-            if (!isset($this->escChars[$c])) {
-                $this->escChars[$c] = $this->escapedChar($c);
+    public static function escapeIri($str)
+    {
+        if (self::$iriEscapeMap === null) {
+            // the only forbidden characters according to 
+            // https://www.w3.org/TR/n-triples/#grammar-production-IRIREF
+            self::$iriEscapeMap = array();
+            foreach (array('<', '>', '"', '{', '}', '|', '^', '`', '\\') as $i) {
+                self::$iriEscapeMap[$i] = sprintf('\\u%04X', ord($i));
             }
-
-            $result .= $this->escChars[$c];
+            for ($i = 0; $i <= 32; $i++) {
+                self::$iriEscapeMap[chr($i)] = sprintf('\\u%04X', ord($i));
+            }
         }
-
-        return $result;
-    }
-
-    /**
-     * @ignore
-     */
-    protected function unicodeCharNo($cUtf)
-    {
-        $bl = strlen($cUtf); /* binary length */
-        $r = 0;
-        switch ($bl) {
-            case 1: /* 0####### (0-127) */
-                $r = ord($cUtf);
-                break;
-            case 2: /* 110##### 10###### = 192+x 128+x */
-                $r = ((ord($cUtf[0]) - 192) * 64) +
-                     (ord($cUtf[1]) - 128);
-                break;
-            case 3: /* 1110#### 10###### 10###### = 224+x 128+x 128+x */
-                $r = ((ord($cUtf[0]) - 224) * 4096) +
-                     ((ord($cUtf[1]) - 128) * 64) +
-                     (ord($cUtf[2]) - 128);
-                break;
-            case 4: /* 1111#### 10###### 10###### 10###### = 240+x 128+x 128+x 128+x */
-                $r = ((ord($cUtf[0]) - 240) * 262144) +
-                     ((ord($cUtf[1]) - 128) * 4096) +
-                     ((ord($cUtf[2]) - 128) * 64) +
-                     (ord($cUtf[3]) - 128);
-                break;
-        }
-        return $r;
-    }
-
-    /**
-     * @ignore
-     */
-    protected function escapedChar($c)
-    {
-        $no = $this->unicodeCharNo($c);
-
-        /* see http://www.w3.org/TR/rdf-testcases/#ntrip_strings */
-        if ($no < 9) {
-            return "\\u" . sprintf('%04X', $no);  /* #x0-#x8 (0-8) */
-        } elseif ($no == 9) {
-            return '\t';                          /* #x9 (9) */
-        } elseif ($no == 10) {
-            return '\n';                          /* #xA (10) */
-        } elseif ($no < 13) {
-            return "\\u" . sprintf('%04X', $no);  /* #xB-#xC (11-12) */
-        } elseif ($no == 13) {
-            return '\r';                          /* #xD (13) */
-        } elseif ($no < 32) {
-            return "\\u" . sprintf('%04X', $no);  /* #xE-#x1F (14-31) */
-        } elseif ($no < 34) {
-            return $c;                            /* #x20-#x21 (32-33) */
-        } elseif ($no == 34) {
-            return '\"';                          /* #x22 (34) */
-        } elseif ($no < 92) {
-            return $c;                            /* #x23-#x5B (35-91) */
-        } elseif ($no == 92) {
-            return '\\\\'; // double backslash    /* #x5C (92) */
-        } elseif ($no < 127) {
-            return $c;                            /* #x5D-#x7E (93-126) */
-        } elseif ($no < 65536) {
-            return "\\u" . sprintf('%04X', $no);  /* #x7F-#xFFFF (128-65535) */
-        } elseif ($no < 1114112) {
-            return "\\U" . sprintf('%08X', $no);  /* #x10000-#x10FFFF (65536-1114111) */
-        } else {
-            return '';                            /* not defined => ignore */
-        }
+        return strtr($str, self::$iriEscapeMap);
     }
 
     /**
@@ -146,7 +100,7 @@ class Ntriples extends Serialiser
      */
     protected function serialiseResource($res)
     {
-        $escaped = $this->escapeString($res);
+        $escaped = self::escapeIri($res);
         if (substr($res, 0, 2) == '_:') {
             return $escaped;
         } else {
@@ -175,23 +129,22 @@ class Ntriples extends Serialiser
         if ($value['type'] == 'uri' or $value['type'] == 'bnode') {
             return $this->serialiseResource($value['value']);
         } elseif ($value['type'] == 'literal') {
-            $escaped = $this->escapeString($value['value']);
+            $escaped = self::escapeLiteral($value['value']);
             if (isset($value['lang'])) {
-                $lang = $this->escapeString($value['lang']);
+                $lang = $value['lang'];
                 return '"' . $escaped . '"' . '@' . $lang;
             } elseif (isset($value['datatype'])) {
-                $datatype = $this->escapeString($value['datatype']);
+                $datatype = self::escapeIri($value['datatype']);
                 return '"' . $escaped . '"' . "^^<$datatype>";
             } else {
                 return '"' . $escaped . '"';
             }
         } else {
             throw new Exception(
-                "Unable to serialise object of type '".$value['type']."' to ntriples: "
+                    "Unable to serialise object of type '" . $value['type'] . "' to ntriples: "
             );
         }
     }
-
 
     /**
      * Serialise an EasyRdf\Graph into N-Triples
@@ -212,16 +165,16 @@ class Ntriples extends Serialiser
             foreach ($graph->toRdfPhp() as $resource => $properties) {
                 foreach ($properties as $property => $values) {
                     foreach ($values as $value) {
-                        $nt .= $this->serialiseResource($resource)." ";
-                        $nt .= "<" . $this->escapeString($property) . "> ";
-                        $nt .= $this->serialiseValue($value)." .\n";
+                        $nt .= $this->serialiseResource($resource) . " ";
+                        $nt .= "<" . self::escapeIri($property) . "> ";
+                        $nt .= $this->serialiseValue($value) . " .\n";
                     }
                 }
             }
             return $nt;
         } else {
             throw new Exception(
-                __CLASS__." does not support: $format"
+                    __CLASS__ . " does not support: $format"
             );
         }
     }

--- a/lib/Serialiser/Turtle.php
+++ b/lib/Serialiser/Turtle.php
@@ -45,7 +45,7 @@ use EasyRdf\Serialiser;
 
 /**
  * Class to serialise an EasyRdf\Graph to Turtle
- * with no external dependencies.
+ * with no external dependancies.
  *
  * http://www.w3.org/TR/turtle/
  *
@@ -66,8 +66,7 @@ class Turtle extends Serialiser
      */
     public static function escapeIri($resourceIri)
     {
-        $escapedIri = str_replace('>', '\\>', $resourceIri);
-        return "<$escapedIri>";
+        return '<' . Ntriples::escapeIri($resourceIri) . '>';
     }
 
     /**
@@ -81,23 +80,7 @@ class Turtle extends Serialiser
      */
     public static function quotedString($value)
     {
-        if (preg_match('/[\t\n\r]/', $value)) {
-            $escaped = str_replace(array('\\', '"""'), array('\\\\', '\\"""'), $value);
-
-            // Check if the last character is a trailing double quote, if so, escape it.
-            $pos = strrpos($escaped, '"');
-
-            if ($pos !== false && $pos + 1 == strlen($escaped)) {
-                $escaped = substr($escaped, 0, -1);
-
-                $escaped .= '\"';
-            }
-
-            return '"""'.$escaped.'"""';
-        } else {
-            $escaped = str_replace(array('\\', '"'), array('\\\\', '\\"'), $value);
-            return '"'.$escaped.'"';
-        }
+        return '"' . Ntriples::escapeLiteral($value) . '"';
     }
 
     /**

--- a/test/EasyRdf/GraphTest.php
+++ b/test/EasyRdf/GraphTest.php
@@ -322,7 +322,7 @@ class GraphTest extends TestCase
             array('headers' => array('Content-Type' => 'text/plain; charset=utf8'))
         );
         $graph = new Graph('http://www.example.com/');
-        $this->assertSame(14, $graph->load());
+        $this->assertSame(15, $graph->load());
         $this->assertStringEquals(
             'Joe Bloggs',
             $graph->get('http://www.example.com/joe#me', 'foaf:name')

--- a/test/EasyRdf/Parser/NtriplesTest.php
+++ b/test/EasyRdf/Parser/NtriplesTest.php
@@ -60,7 +60,7 @@ class NtriplesTest extends TestCase
     public function testParse()
     {
         $count = $this->parser->parse($this->graph, $this->nt_data, 'ntriples', null);
-        $this->assertSame(14, $count);
+        $this->assertSame(15, $count);
 
         $joe = $this->graph->resource('http://www.example.com/joe#me');
         $this->assertNotNull($joe);
@@ -363,7 +363,7 @@ class NtriplesTest extends TestCase
     {
         $this->setExpectedException(
             'EasyRdf\Parser\Exception',
-            'Failed to parse object: foobar on line 1'
+            'Failed to parse statement on line 1'
         );
         $this->parser->parse(
             $this->graph,

--- a/test/EasyRdf/Serialiser/NtriplesArray.php
+++ b/test/EasyRdf/Serialiser/NtriplesArray.php
@@ -90,7 +90,7 @@ class NtriplesArray extends Ntriples
                         $triples,
                         array(
                             's' => $this->serialiseResource($resource),
-                            'p' => "<" . $this->escapeString($property) . ">",
+                            'p' => "<" . self::escapeIri($property) . ">",
                             'o' => $this->serialiseValue($value)
                         )
                     );

--- a/test/EasyRdf/Serialiser/NtriplesTest.php
+++ b/test/EasyRdf/Serialiser/NtriplesTest.php
@@ -289,8 +289,8 @@ class NtriplesTest extends TestCase
     public function testIssue219Unicode()
     {
         $pairs = array(
-            '位' => '"\u4F4D"',
-            "Дуглас Адамс" => '"\u0414\u0443\u0433\u043B\u0430\u0441 \u0410\u0434\u0430\u043C\u0441"',
+            '位' => '"位"',
+            "Дуглас Адамс" => '"Дуглас Адамс"',
         );
 
         $serializer = new Ntriples();

--- a/test/EasyRdf/Serialiser/TurtleTest.php
+++ b/test/EasyRdf/Serialiser/TurtleTest.php
@@ -74,7 +74,7 @@ class TurtleTest extends TestCase
     public function testEscapeIriAngleBracket()
     {
         $this->assertSame(
-            '<http://google.com/search?q=<\>>',
+            '<http://google.com/search?q=\u003C\u003E>',
             Turtle::escapeIri('http://google.com/search?q=<>')
         );
     }
@@ -90,7 +90,7 @@ class TurtleTest extends TestCase
     public function testMultilineQuotedString()
     {
         $this->assertSame(
-            '"""Hello	World"""',
+            '"Hello	World"',
             Turtle::quotedString('Hello	World')
         );
     }
@@ -126,7 +126,7 @@ class TurtleTest extends TestCase
     {
         $res = $this->graph->resource('http://google.com/search?q=<>');
         $this->assertSame(
-            '<http://google.com/search?q=<\>>',
+            '<http://google.com/search?q=\u003C\u003E>',
             $this->serialiser->serialiseResource($res)
         );
     }
@@ -144,7 +144,7 @@ class TurtleTest extends TestCase
     {
         $literal = new Literal("Hello\nWorld");
         $this->assertSame(
-            "\"\"\"Hello\nWorld\"\"\"",
+            "\"Hello\\nWorld\"",
             $this->serialiser->serialiseLiteral($literal)
         );
     }
@@ -517,7 +517,7 @@ class TurtleTest extends TestCase
         $turtle = $this->serialiser->serialise($this->graph, 'turtle');
         $this->assertSame(
             "@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n\n".
-            "<http://example.com/joe#me> foaf:name \"\"\"Line 1\nLine 2\"\"\" .\n",
+            "<http://example.com/joe#me> foaf:name \"Line 1\\nLine 2\" .\n",
             $turtle
         );
     }
@@ -530,7 +530,7 @@ class TurtleTest extends TestCase
         $turtle = $this->serialiser->serialise($this->graph, 'turtle');
         $this->assertSame(
             "@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n\n".
-            "<http://example.com/joe#me> foaf:name \"\"\"\t\\\"\"\"\t\"\"\" .\n",
+            "<http://example.com/joe#me> foaf:name \"\t\\\"\\\"\\\"\t\" .\n",
             $turtle
         );
     }
@@ -543,7 +543,7 @@ class TurtleTest extends TestCase
         $turtle = $this->serialiser->serialise($this->graph, 'turtle');
         $this->assertSame(
             "@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n\n".
-            "<http://example.com/joe#me> foaf:name \"\"\"\t\"\"Doe\\\"\"\"\" .\n",
+            "<http://example.com/joe#me> foaf:name \"\t\\\"\\\"Doe\\\"\" .\n",
             $turtle
         );
     }

--- a/test/fixtures/foaf.nt
+++ b/test/fixtures/foaf.nt
@@ -1,6 +1,7 @@
 <http://www.example.com/joe/foaf.rdf> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/PersonalProfileDocument> .
 <http://www.example.com/joe/foaf.rdf> <http://www.w3.org/2000/01/rdf-schema#label> "Joe Bloggs' FOAF File" .
-<http://www.example.com/joe/foaf.rdf> <http://xmlns.com/foaf/0.1/maker> <http://www.example.com/joe#me> .
+# full line comment
+<http://www.example.com/joe/foaf.rdf> <http://xmlns.com/foaf/0.1/maker> <http://www.example.com/joe#me> . # end of line comment
 <http://www.example.com/joe/foaf.rdf> <http://xmlns.com/foaf/0.1/primaryTopic> <http://www.example.com/joe#me> .
 <http://www.example.com/joe#me> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> .
 <http://www.example.com/joe#me> <http://xmlns.com/foaf/0.1/title> "Mr" .
@@ -8,6 +9,7 @@
 <http://www.example.com/joe#me> <http://xmlns.com/foaf/0.1/firstName> "Joe" .
 <http://www.example.com/joe#me> <http://xmlns.com/foaf/0.1/family_name> "Bloggs" .
 <http://www.example.com/joe#me> <http://xmlns.com/foaf/0.1/homepage> <http://www.example.com/joe/> .
+<http://www.example.com/joe#me> <http://xmlns.com/foaf/0.1/age> "34"^^<http://www.w3.org/2001/XMLSchema#integer> .
 _:genid1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Project> .
 _:genid1 <http://xmlns.com/foaf/0.1/name> "Joe's Current Project" .
 _:genid1 <http://xmlns.com/foaf/0.1/homepage> <http://www.example.com/project> .


### PR DESCRIPTION
A bunch of changes to the ntriples and turtle serializer and parser:

* Ntriples serializer doesn't encode unicode characters any more (as they are valid and escaping them takes a lot of time and involves a lot of strings copying).
* Ntriples serializer applies different escaping rules to IRIs and literals (according to https://www.w3.org/TR/n-triples/#n-triples-grammar)
* Ntriples parser allows comments at the end of a line (as defined in https://www.w3.org/TR/n-triples/#n-triples-grammar)
* Turtle serializer simply uses Ntriples escape routine for escaping literals (which is perfectly valid and reduces the codebase)
* Turtle parser splits input into an array with `preg_split('//u', $data, null, PREG_SPLIT_NO_EMPTY);` which allows performant character position-based access to the parsed input. The previous implementation using `mb_substr()` was extremely slow for larger inputs.