### PR TITLE
Enforce coding styles using php-cs-fixer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /vendor
 /composer.phar
 /composer.lock
+/.php_cs.cache

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,23 @@
+<?php
+
+return PhpCsFixer\Config::create()
+    ->setRules([
+        '@Symfony' => true,
+        '@Symfony:risky' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'no_empty_phpdoc' => true,
+        'no_unused_imports' => true,
+        'no_superfluous_phpdoc_tags' => true,
+        'ordered_imports' => true,
+        'phpdoc_summary' => false,
+        'protected_to_private' => false,
+     ])
+    ->setRiskyAllowed(true)
+    ->setFinder(
+        PhpCsFixer\Finder::create()
+        ->files()
+        ->in(__DIR__ . '/examples')
+        ->in(__DIR__ . '/lib')
+        ->in(__DIR__ . '/test')
+        ->name('*.php')
+    );

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,14 @@ matrix:
     - php: 7.1
     - php: 7.2
     - php: 7.3
-    - php: 7.4
 
 jobs:
   allow_failures:
     - php: nightly
+  include:
+    - php: 7.4
+      env: LINTER_RUN=run
+      env: COVERAGE_FLAGS="--coverage-clover coverage/clover.xml"
 
 sudo: required
 
@@ -34,7 +37,8 @@ before_script:
 
 script:
   - make lint
-  - vendor/bin/phpunit --coverage-clover gen/coverage/clover.xml
+  - if [ "$LINTER_RUN" = "run" ]; then php vendor/bin/php-cs-fixer fix --verbose --dry-run ; fi;
+  - php vendor/bin/phpunit $COVERAGE_FLAGS
 
 after_success:
     # Submit coverage report to Coveralls servers, see .coveralls.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
   - sudo apt-get install -q -y graphviz raptor2-utils
 
 before_script:
-  - travis_retry composer install --no-interaction --prefer-dist
+  - travis_retry composer install --prefer-dist --no-progress --no-suggest --optimize-autoloader
 
 script:
   - make lint
@@ -42,4 +42,5 @@ script:
 
 after_success:
     # Submit coverage report to Coveralls servers, see .coveralls.yml
-    - travis_retry php vendor/bin/php-coveralls -v
+    # only if COVERAGE_FLAGS variable is set.
+    - if [ ! -z "${COVERAGE_FLAGS}" ]; then travis_retry php vendor/bin/php-coveralls -v ; fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
     - php: 7.1
     - php: 7.2
     - php: 7.3
+    - php: 7.4
 
 jobs:
   allow_failures:
@@ -17,8 +18,6 @@ jobs:
     - php: 7.4
       env: LINTER_RUN=run
       env: COVERAGE_FLAGS="--coverage-clover coverage/clover.xml"
-
-sudo: required
 
 git:
     depth: 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,13 @@ matrix:
     - php: 7.2
     - php: 7.3
     - php: 7.4
+    # special case: run linter and check coding styles
+    - php: 7.4
+      env: LINTER_RUN=run COVERAGE_FLAGS="--coverage-clover coverage/clover.xml"
 
 jobs:
   allow_failures:
     - php: nightly
-  include:
-    - php: 7.4
-      env: LINTER_RUN=run
-      env: COVERAGE_FLAGS="--coverage-clover coverage/clover.xml"
 
 git:
     depth: 1

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
         "semsol/arc2": "^2.4"
     },
     "require-dev": {
+        "friendsofphp/php-cs-fixer": "^2.16.3",
         "ml/json-ld": "^1.1",
         "php-coveralls/php-coveralls": "^2.2",
         "phpunit/phpunit": "~4.8.36|^6|^7",

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "semsol/arc2": "^2.4"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.16.3",
+        "friendsofphp/php-cs-fixer": "^2.0",
         "ml/json-ld": "^1.1",
         "php-coveralls/php-coveralls": "^2.2",
         "phpunit/phpunit": "~4.8.36|^6|^7",

--- a/examples/basic.php
+++ b/examples/basic.php
@@ -7,12 +7,10 @@
      * the primary topic of the document (me, Nicholas Humfrey) is returned
      * and then used to display my name.
      *
-     * @package    EasyRdf
      * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
      * @license    http://unlicense.org/
      */
-
-    require_once realpath(__DIR__.'/..')."/vendor/autoload.php";
+    require_once realpath(__DIR__.'/..').'/vendor/autoload.php';
 ?>
 <html>
 <head>
@@ -26,7 +24,7 @@
 ?>
 
 <p>
-  My name is: <?= $me->get('foaf:name') ?>
+  My name is: <?= $me->get('foaf:name'); ?>
 </p>
 
 </body>

--- a/examples/basic_sparql.php
+++ b/examples/basic_sparql.php
@@ -10,13 +10,11 @@
      * Note how the namespace prefix declarations are automatically
      * added to the query.
      *
-     * @package    EasyRdf
      * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
      * @license    http://unlicense.org/
      */
-
-    require_once realpath(__DIR__.'/..')."/vendor/autoload.php";
-    require_once __DIR__."/html_tag_helpers.php";
+    require_once realpath(__DIR__.'/..').'/vendor/autoload.php';
+    require_once __DIR__.'/html_tag_helpers.php';
 
     // Setup some additional prefixes for DBpedia
     \EasyRdf\RdfNamespace::set('category', 'http://dbpedia.org/resource/Category:');
@@ -46,11 +44,11 @@
         '} ORDER BY ?label'
     );
     foreach ($result as $row) {
-        echo "<li>".link_to($row->label, $row->country)."</li>\n";
+        echo '<li>'.link_to($row->label, $row->country)."</li>\n";
     }
 ?>
 </ul>
-<p>Total number of countries: <?= $result->numRows() ?></p>
+<p>Total number of countries: <?= $result->numRows(); ?></p>
 
 </body>
 </html>

--- a/examples/converter.php
+++ b/examples/converter.php
@@ -1,4 +1,5 @@
 <?php
+
     /**
      * Convert RDF from one format to another
      *
@@ -12,16 +13,14 @@
      * The input data is loaded or parsed into an EasyRdf\Graph.
      * That graph is than outputted again in the desired output format.
      *
-     * @package    EasyRdf
      * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
      * @license    http://unlicense.org/
      */
+    require_once realpath(__DIR__.'/..').'/vendor/autoload.php';
+    require_once __DIR__.'/html_tag_helpers.php';
 
-    require_once realpath(__DIR__.'/..')."/vendor/autoload.php";
-    require_once __DIR__."/html_tag_helpers.php";
-
-    $input_format_options = array('Guess' => 'guess');
-    $output_format_options = array();
+    $input_format_options = ['Guess' => 'guess'];
+    $output_format_options = [];
     foreach (\EasyRdf\Format::getFormats() as $format) {
         if ($format->getSerialiserClass()) {
             $output_format_options[$format->getLabel()] = $format->getName();
@@ -45,21 +44,21 @@
 
     // Display the form, if raw option isn't set
     if (!isset($_REQUEST['raw'])) {
-        print "<html>\n";
-        print "<head><title>EasyRdf Converter</title></head>\n";
-        print "<body>\n";
-        print "<h1>EasyRdf Converter</h1>\n";
+        echo "<html>\n";
+        echo "<head><title>EasyRdf Converter</title></head>\n";
+        echo "<body>\n";
+        echo "<h1>EasyRdf Converter</h1>\n";
 
-        print "<div style='margin: 10px'>\n";
-        print form_tag();
-        print label_tag('data', 'Input Data: ').'<br />'.text_area_tag('data', '', array('cols'=>80, 'rows'=>10)) . "<br />\n";
-        print label_tag('uri', 'or Uri: ').text_field_tag('uri', 'http://www.dajobe.org/foaf.rdf', array('size'=>80)) . "<br />\n";
-        print label_tag('input_format', 'Input Format: ').select_tag('input_format', $input_format_options) . "<br />\n";
-        print label_tag('output_format', 'Output Format: ').select_tag('output_format', $output_format_options) . "<br />\n";
-        print label_tag('raw', 'Raw Output: ').check_box_tag('raw') . "<br />\n";
-        print reset_tag() . submit_tag();
-        print form_end_tag();
-        print "</div>\n";
+        echo "<div style='margin: 10px'>\n";
+        echo form_tag();
+        echo label_tag('data', 'Input Data: ').'<br />'.text_area_tag('data', '', ['cols' => 80, 'rows' => 10])."<br />\n";
+        echo label_tag('uri', 'or Uri: ').text_field_tag('uri', 'http://www.dajobe.org/foaf.rdf', ['size' => 80])."<br />\n";
+        echo label_tag('input_format', 'Input Format: ').select_tag('input_format', $input_format_options)."<br />\n";
+        echo label_tag('output_format', 'Output Format: ').select_tag('output_format', $output_format_options)."<br />\n";
+        echo label_tag('raw', 'Raw Output: ').check_box_tag('raw')."<br />\n";
+        echo reset_tag().submit_tag();
+        echo form_end_tag();
+        echo "</div>\n";
     }
 
     if (isset($_REQUEST['uri']) or isset($_REQUEST['data'])) {
@@ -83,13 +82,13 @@
         // Send the output back to the client
         if (isset($_REQUEST['raw'])) {
             header('Content-Type: '.$format->getDefaultMimeType());
-            print $output;
+            echo $output;
         } else {
-            print '<pre>'.htmlspecialchars($output).'</pre>';
+            echo '<pre>'.htmlspecialchars($output).'</pre>';
         }
     }
 
     if (!isset($_REQUEST['raw'])) {
-        print "</body>\n";
-        print "</html>\n";
+        echo "</body>\n";
+        echo "</html>\n";
     }

--- a/examples/dump.php
+++ b/examples/dump.php
@@ -9,13 +9,11 @@
      * The call to preg_replace() replaces links in the page with
      * links back to this dump script.
      *
-     * @package    EasyRdf
      * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
      * @license    http://unlicense.org/
      */
-
-    require_once realpath(__DIR__.'/..')."/vendor/autoload.php";
-    require_once __DIR__."/html_tag_helpers.php";
+    require_once realpath(__DIR__.'/..').'/vendor/autoload.php';
+    require_once __DIR__.'/html_tag_helpers.php';
 ?>
 <html>
 <head><title>EasyRdf Graph Dumper</title></head>
@@ -23,34 +21,35 @@
 <h1>EasyRdf Graph Dumper</h1>
 
 <div style="margin: 10px">
-  <?= form_tag() ?>
-  URI: <?= text_field_tag('uri', 'http://mmt.me.uk/foaf.rdf', array('size'=>80)) ?><br />
-  Format: <?= label_tag('format_html', 'HTML').' '.radio_button_tag('format', 'html', true) ?>
-          <?= label_tag('format_text', 'Text').' '.radio_button_tag('format', 'text') ?><br />
+  <?= form_tag(); ?>
+  URI: <?= text_field_tag('uri', 'http://mmt.me.uk/foaf.rdf', ['size' => 80]); ?><br />
+  Format: <?= label_tag('format_html', 'HTML').' '.radio_button_tag('format', 'html', true); ?>
+          <?= label_tag('format_text', 'Text').' '.radio_button_tag('format', 'text'); ?><br />
 
-  <?= submit_tag() ?>
-  <?= form_end_tag() ?>
+  <?= submit_tag(); ?>
+  <?= form_end_tag(); ?>
 </div>
 
 <?php
     if (isset($_REQUEST['uri'])) {
         $graph = \EasyRdf\Graph::newAndLoad($_REQUEST['uri']);
         if ($graph) {
-            if (isset($_REQUEST['format']) && $_REQUEST['format'] == 'text') {
-                print "<pre>".$graph->dump('text')."</pre>";
+            if (isset($_REQUEST['format']) && 'text' == $_REQUEST['format']) {
+                echo '<pre>'.$graph->dump('text').'</pre>';
             } else {
                 $dump = $graph->dump('html');
-                print preg_replace_callback("/ href='([^#][^']*)'/", 'makeLinkLocal', $dump);
+                echo preg_replace_callback("/ href='([^#][^']*)'/", 'makeLinkLocal', $dump);
             }
         } else {
-            print "<p>Failed to create graph.</p>";
+            echo '<p>Failed to create graph.</p>';
         }
     }
 
-    # Callback function to re-write links in the dump to point back to this script
+    // Callback function to re-write links in the dump to point back to this script
     function makeLinkLocal($matches)
     {
         $href = $matches[1];
+
         return " href='?uri=".urlencode($href)."#$href'";
     }
 ?>

--- a/examples/foafinfo.php
+++ b/examples/foafinfo.php
@@ -10,40 +10,38 @@
      * and description are shown, along with a list of the
      * person's friends.
      *
-     * @package    EasyRdf
      * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
      * @license    http://unlicense.org/
      */
-
-    require_once realpath(__DIR__.'/..')."/vendor/autoload.php";
-    require_once __DIR__."/html_tag_helpers.php";
+    require_once realpath(__DIR__.'/..').'/vendor/autoload.php';
+    require_once __DIR__.'/html_tag_helpers.php';
 ?>
 <html>
 <head><title>EasyRdf FOAF Info Example</title></head>
 <body>
 <h1>EasyRdf FOAF Info Example</h1>
 
-<?= form_tag() ?>
-<?= text_field_tag('uri', 'http://njh.me/foaf.rdf', array('size'=>50)) ?>
-<?= submit_tag() ?>
-<?= form_end_tag() ?>
+<?= form_tag(); ?>
+<?= text_field_tag('uri', 'http://njh.me/foaf.rdf', ['size' => 50]); ?>
+<?= submit_tag(); ?>
+<?= form_end_tag(); ?>
 
 <?php
     if (isset($_REQUEST['uri'])) {
         $graph = \EasyRdf\Graph::newAndLoad($_REQUEST['uri']);
-        if ($graph->type() == 'foaf:PersonalProfileDocument') {
+        if ('foaf:PersonalProfileDocument' == $graph->type()) {
             $person = $graph->primaryTopic();
-        } elseif ($graph->type() == 'foaf:Person') {
+        } elseif ('foaf:Person' == $graph->type()) {
             $person = $graph->resource();
         }
     }
 
     if (isset($person)) {
-?>
+        ?>
 
 <dl>
-  <dt>Name:</dt><dd><?= $person->get('foaf:name') ?></dd>
-  <dt>Homepage:</dt><dd><?= link_to($person->get('foaf:homepage')) ?></dd>
+  <dt>Name:</dt><dd><?= $person->get('foaf:name'); ?></dd>
+  <dt>Homepage:</dt><dd><?= link_to($person->get('foaf:homepage')); ?></dd>
 </dl>
 
 <?php
@@ -58,7 +56,7 @@
             if ($friend->isBNode()) {
                 echo "<li>$label</li>";
             } else {
-                echo "<li>".link_to_self($label, 'uri='.urlencode($friend))."</li>";
+                echo '<li>'.link_to_self($label, 'uri='.urlencode($friend)).'</li>';
             }
         }
         echo "</ul>\n";
@@ -71,7 +69,7 @@
                 if ($interest->isBNode()) {
                     echo "<li>$label</li>";
                 } else {
-                    echo "<li>".$interest->htmlLink($label)."</li>";
+                    echo '<li>'.$interest->htmlLink($label).'</li>';
                 }
             }
         }
@@ -79,7 +77,7 @@
     }
 
     if (isset($graph)) {
-        echo "<br />";
+        echo '<br />';
         echo $graph->dump();
     }
 ?>

--- a/examples/foafmaker.php
+++ b/examples/foafmaker.php
@@ -6,13 +6,11 @@
      * The fields in the HTML form are inserted into an empty
      * EasyRdf\Graph and then serialised to the chosen format.
      *
-     * @package    EasyRdf
      * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
      * @license    http://unlicense.org/
      */
-
-    require_once realpath(__DIR__.'/..')."/vendor/autoload.php";
-    require_once __DIR__."/html_tag_helpers.php";
+    require_once realpath(__DIR__.'/..').'/vendor/autoload.php';
+    require_once __DIR__.'/html_tag_helpers.php';
 
     if (isset($_REQUEST['enable_arc']) && $_REQUEST['enable_arc']) {
         \EasyRdf\Format::registerSerialiser('ntriples', 'EasyRdf\Serialiser\Arc');
@@ -27,7 +25,7 @@
         \EasyRdf\Format::registerSerialiser('turtle', 'EasyRdf\Serialiser\Rapper');
     }
 
-    $format_options = array();
+    $format_options = [];
     foreach (\EasyRdf\Format::getFormats() as $format) {
         if ($format->getSerialiserClass()) {
             $format_options[$format->getLabel()] = $format->getName();
@@ -39,44 +37,43 @@
 <body>
 <h1>EasyRdf FOAF Maker Example</h1>
 
-<?= form_tag(null, array('method' => 'POST')) ?>
+<?= form_tag(null, ['method' => 'POST']); ?>
 
 <h2>Your Identifier</h2>
-<?= labeled_text_field_tag('uri', 'http://www.example.com/joe#me', array('size'=>40)) ?><br />
+<?= labeled_text_field_tag('uri', 'http://www.example.com/joe#me', ['size' => 40]); ?><br />
 
 <h2>Your details</h2>
-<?= labeled_text_field_tag('title', 'Mr', array('size'=>8)) ?><br />
-<?= labeled_text_field_tag('given_name', 'Joseph') ?><br />
-<?= labeled_text_field_tag('family_name', 'Bloggs') ?><br />
-<?= labeled_text_field_tag('nickname', 'Joe') ?><br />
-<?= labeled_text_field_tag('email', 'joe@example.com') ?><br />
-<?= labeled_text_field_tag('homepage', 'http://www.example.com/', array('size'=>40)) ?><br />
+<?= labeled_text_field_tag('title', 'Mr', ['size' => 8]); ?><br />
+<?= labeled_text_field_tag('given_name', 'Joseph'); ?><br />
+<?= labeled_text_field_tag('family_name', 'Bloggs'); ?><br />
+<?= labeled_text_field_tag('nickname', 'Joe'); ?><br />
+<?= labeled_text_field_tag('email', 'joe@example.com'); ?><br />
+<?= labeled_text_field_tag('homepage', 'http://www.example.com/', ['size' => 40]); ?><br />
 
 <h2>People you know</h2>
-<?= labeled_text_field_tag('person_1', 'http://www.example.com/dave#me', array('size'=>40)) ?><br />
-<?= labeled_text_field_tag('person_2', '', array('size'=>40)) ?><br />
-<?= labeled_text_field_tag('person_3', '', array('size'=>40)) ?><br />
-<?= labeled_text_field_tag('person_4', '', array('size'=>40)) ?><br />
+<?= labeled_text_field_tag('person_1', 'http://www.example.com/dave#me', ['size' => 40]); ?><br />
+<?= labeled_text_field_tag('person_2', '', ['size' => 40]); ?><br />
+<?= labeled_text_field_tag('person_3', '', ['size' => 40]); ?><br />
+<?= labeled_text_field_tag('person_4', '', ['size' => 40]); ?><br />
 
 <h2>Output</h2>
-Enable Arc 2? <?= check_box_tag('enable_arc') ?><br />
-Enable Rapper? <?= check_box_tag('enable_rapper') ?><br />
-<?= label_tag('format').select_tag('format', $format_options, 'rdfxml') ?><br />
+Enable Arc 2? <?= check_box_tag('enable_arc'); ?><br />
+Enable Rapper? <?= check_box_tag('enable_rapper'); ?><br />
+<?= label_tag('format').select_tag('format', $format_options, 'rdfxml'); ?><br />
 
-<?= submit_tag() ?>
-<?= form_end_tag() ?>
+<?= submit_tag(); ?>
+<?= form_end_tag(); ?>
 
 
 <?php
     if (isset($_REQUEST['uri'])) {
-
         $graph = new \EasyRdf\Graph();
 
-        # 1st Technique
+        // 1st Technique
         $me = $graph->resource($_REQUEST['uri'], 'foaf:Person');
         $me->set('foaf:name', $_REQUEST['title'].' '.$_REQUEST['given_name'].' '.$_REQUEST['family_name']);
         if ($_REQUEST['email']) {
-            $email = $graph->resource("mailto:".$_REQUEST['email']);
+            $email = $graph->resource('mailto:'.$_REQUEST['email']);
             $me->add('foaf:mbox', $email);
         }
         if ($_REQUEST['homepage']) {
@@ -84,26 +81,26 @@ Enable Rapper? <?= check_box_tag('enable_rapper') ?><br />
             $me->add('foaf:homepage', $homepage);
         }
 
-        # 2nd Technique
+        // 2nd Technique
         $graph->addLiteral($_REQUEST['uri'], 'foaf:title', $_REQUEST['title']);
         $graph->addLiteral($_REQUEST['uri'], 'foaf:givenname', $_REQUEST['given_name']);
         $graph->addLiteral($_REQUEST['uri'], 'foaf:family_name', $_REQUEST['family_name']);
         $graph->addLiteral($_REQUEST['uri'], 'foaf:nick', $_REQUEST['nickname']);
 
-        # Add friends
-        for($i=1; $i<=4; $i++) {
+        // Add friends
+        for ($i = 1; $i <= 4; ++$i) {
             if ($_REQUEST["person_$i"]) {
                 $person = $graph->resource($_REQUEST["person_$i"]);
                 $graph->add($me, 'foaf:knows', $person);
             }
         }
 
-        # Finally output the graph
+        // Finally output the graph
         $data = $graph->serialise($_REQUEST['format']);
         if (!is_scalar($data)) {
             $data = var_export($data, true);
         }
-        print "<pre>".htmlspecialchars($data)."</pre>";
+        echo '<pre>'.htmlspecialchars($data).'</pre>';
     }
 
 ?>

--- a/examples/graph_direct.php
+++ b/examples/graph_direct.php
@@ -5,12 +5,10 @@
      * Triple data is inserted and retrieved directly from a graph object,
      * where it is stored internally as an associative array.
      *
-     * @package    EasyRdf
      * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
      * @license    http://unlicense.org/
      */
-
-    require_once realpath(__DIR__.'/..')."/vendor/autoload.php";
+    require_once realpath(__DIR__.'/..').'/vendor/autoload.php';
 ?>
 <html>
 <head>
@@ -20,29 +18,29 @@
 
 <?php
   $graph = new \EasyRdf\Graph();
-  $graph->addResource("http://example.com/joe", "rdf:type", "foaf:Person");
-  $graph->addLiteral("http://example.com/joe", "foaf:name", "Joe Bloggs");
-  $graph->addLiteral("http://example.com/joe", "foaf:name", "Joseph Bloggs");
-  $graph->add("http://example.com/joe", "rdfs:label", "Joe");
+  $graph->addResource('http://example.com/joe', 'rdf:type', 'foaf:Person');
+  $graph->addLiteral('http://example.com/joe', 'foaf:name', 'Joe Bloggs');
+  $graph->addLiteral('http://example.com/joe', 'foaf:name', 'Joseph Bloggs');
+  $graph->add('http://example.com/joe', 'rdfs:label', 'Joe');
 
-  $graph->setType("http://njh.me/", "foaf:Person");
-  $graph->add("http://njh.me/", "rdfs:label", "Nick");
-  $graph->addLiteral("http://njh.me/", "foaf:name", "Nicholas Humfrey");
-  $graph->addResource("http://njh.me/", "foaf:homepage", "http://www.aelius.com/njh/");
+  $graph->setType('http://njh.me/', 'foaf:Person');
+  $graph->add('http://njh.me/', 'rdfs:label', 'Nick');
+  $graph->addLiteral('http://njh.me/', 'foaf:name', 'Nicholas Humfrey');
+  $graph->addResource('http://njh.me/', 'foaf:homepage', 'http://www.aelius.com/njh/');
 ?>
 
 <p>
-  <b>Name:</b> <?= $graph->get("http://example.com/joe", "foaf:name") ?> <br />
-  <b>Names:</b> <?= $graph->join("http://example.com/joe", "foaf:name") ?> <br />
+  <b>Name:</b> <?= $graph->get('http://example.com/joe', 'foaf:name'); ?> <br />
+  <b>Names:</b> <?= $graph->join('http://example.com/joe', 'foaf:name'); ?> <br />
 
-  <b>Label:</b> <?= $graph->label("http://njh.me/") ?> <br />
-  <b>Properties:</b> <?= join(', ', $graph->properties("http://example.com/joe")) ?> <br />
-  <b>PropertyUris:</b> <?= join(', ', $graph->propertyUris("http://example.com/joe")) ?> <br />
-  <b>People:</b> <?= join(', ', $graph->allOfType('foaf:Person')) ?> <br />
-  <b>Unknown:</b> <?= $graph->get("http://example.com/joe", "unknown:property") ?> <br />
+  <b>Label:</b> <?= $graph->label('http://njh.me/'); ?> <br />
+  <b>Properties:</b> <?= implode(', ', $graph->properties('http://example.com/joe')); ?> <br />
+  <b>PropertyUris:</b> <?= implode(', ', $graph->propertyUris('http://example.com/joe')); ?> <br />
+  <b>People:</b> <?= implode(', ', $graph->allOfType('foaf:Person')); ?> <br />
+  <b>Unknown:</b> <?= $graph->get('http://example.com/joe', 'unknown:property'); ?> <br />
 </p>
 
-<?= $graph->dump() ?>
+<?= $graph->dump(); ?>
 
 </body>
 </html>

--- a/examples/graphstore.php
+++ b/examples/graphstore.php
@@ -9,12 +9,10 @@
      * Note that you will need a graph store, for example RedStore,
      * running on your local machine in order to test this example.
      *
-     * @package    EasyRdf
      * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
      * @license    http://unlicense.org/
      */
-
-    require_once realpath(__DIR__.'/..')."/vendor/autoload.php";
+    require_once realpath(__DIR__.'/..').'/vendor/autoload.php';
 ?>
 <html>
 <head>
@@ -34,7 +32,7 @@
 
   // Get the graph back out of the graph store and display it
   $graph2 = $gs->get('time.rdf');
-  print $graph2->dump();
+  echo $graph2->dump();
 ?>
 
 </body>

--- a/examples/graphviz.php
+++ b/examples/graphviz.php
@@ -11,19 +11,17 @@
      * Rending a graph to an image will only work if you have the
      * GraphViz 'dot' command installed.
      *
-     * @package    EasyRdf
      * @copyright  Copyright (c) 2012-2013 Nicholas J Humfrey
      * @license    http://unlicense.org/
      */
+    require_once realpath(__DIR__.'/..').'/vendor/autoload.php';
+    require_once __DIR__.'/html_tag_helpers.php';
 
-    require_once realpath(__DIR__.'/..')."/vendor/autoload.php";
-    require_once __DIR__."/html_tag_helpers.php";
-
-    $formats = array(
+    $formats = [
       'PNG' => 'png',
       'GIF' => 'gif',
-      'SVG' => 'svg'
-    );
+      'SVG' => 'svg',
+    ];
 
     $format = \EasyRdf\Format::getFormat(
         isset($_REQUEST['format']) ? $_REQUEST['format'] : 'png'
@@ -50,7 +48,7 @@
 
     // If this is a request for the image, just render it and exit
     if (isset($_REQUEST['image'])) {
-        header("Content-Type: ".$format->getDefaultMimeType());
+        header('Content-Type: '.$format->getDefaultMimeType());
         echo $gv->renderImage($graph, $format);
         exit;
     }
@@ -70,12 +68,12 @@
 </form>
 
 <div>
-    <img src='?image&<?=$_SERVER["QUERY_STRING"]?>' />
+    <img src='?image&<?=$_SERVER['QUERY_STRING']; ?>' />
 </div>
 
 <pre style="margin: 0.5em; padding:0.5em; background-color:#eee; border:dashed 1px grey;">
 <?php
-    print htmlspecialchars(
+    echo htmlspecialchars(
         $gv->serialise($graph, 'dot')
     );
 ?>

--- a/examples/html_tag_helpers.php
+++ b/examples/html_tag_helpers.php
@@ -44,175 +44,186 @@ echo form_end_tag();
 
 */
 
-
 function tag_options($options)
 {
-    $html = "";
+    $html = '';
     foreach ($options as $key => $value) {
         if ($key and $value) {
-            $html .= " ".htmlspecialchars($key)."=\"".
-                         htmlspecialchars($value)."\"";
+            $html .= ' '.htmlspecialchars($key).'="'.
+                         htmlspecialchars($value).'"';
         }
     }
+
     return $html;
 }
 
-function tag($name, $options = array(), $open = false)
+function tag($name, $options = [], $open = false)
 {
-    return "<$name".tag_options($options).($open ? ">" : " />");
+    return "<$name".tag_options($options).($open ? '>' : ' />');
 }
 
-function content_tag($name, $content = null, $options = array())
+function content_tag($name, $content = null, $options = [])
 {
-    return "<$name".tag_options($options).">".
+    return "<$name".tag_options($options).'>'.
            htmlspecialchars($content)."</$name>";
 }
 
-function link_to($text, $uri = null, $options = array())
+function link_to($text, $uri = null, $options = [])
 {
-    if ($uri == null) $uri = $text;
-    $options = array_merge(array('href' => $uri), $options);
+    if (null == $uri) {
+        $uri = $text;
+    }
+    $options = array_merge(['href' => $uri], $options);
+
     return content_tag('a', $text, $options);
 }
 
-function link_to_self($text, $query_string, $options = array())
+function link_to_self($text, $query_string, $options = [])
 {
     return link_to($text, $_SERVER['PHP_SELF'].'?'.$query_string, $options);
 }
 
-function image_tag($src, $options = array())
+function image_tag($src, $options = [])
 {
-    $options = array_merge(array('src' => $src), $options);
+    $options = array_merge(['src' => $src], $options);
+
     return tag('img', $options);
 }
 
-function input_tag($type, $name, $value = null, $options = array())
+function input_tag($type, $name, $value = null, $options = [])
 {
     $options = array_merge(
-        array(
+        [
             'type' => $type,
             'name' => $name,
             'id' => $name,
-            'value' => $value
-        ),
+            'value' => $value,
+        ],
         $options
     );
+
     return tag('input', $options);
 }
 
-function text_field_tag($name, $default = null, $options = array())
+function text_field_tag($name, $default = null, $options = [])
 {
     $value = isset($_REQUEST[$name]) ? $_REQUEST[$name] : $default;
+
     return input_tag('text', $name, $value, $options);
 }
 
-function text_area_tag($name, $default = null, $options = array())
+function text_area_tag($name, $default = null, $options = [])
 {
     $content = isset($_REQUEST[$name]) ? $_REQUEST[$name] : $default;
     $options = array_merge(
-        array(
+        [
             'name' => $name,
             'id' => $name,
             'cols' => 60,
-            'rows' => 5
-        ),
+            'rows' => 5,
+        ],
         $options
     );
+
     return content_tag('textarea', $content, $options);
 }
 
-function hidden_field_tag($name, $default = null, $options = array())
+function hidden_field_tag($name, $default = null, $options = [])
 {
     $value = isset($_REQUEST[$name]) ? $_REQUEST[$name] : $default;
+
     return input_tag('hidden', $name, $value, $options);
 }
 
-function password_field_tag($name = 'password', $default = null, $options = array())
+function password_field_tag($name = 'password', $default = null, $options = [])
 {
     $value = isset($_REQUEST[$name]) ? $_REQUEST[$name] : $default;
+
     return input_tag('password', $name, $value, $options);
 }
 
-function radio_button_tag($name, $value, $default = false, $options = array())
+function radio_button_tag($name, $value, $default = false, $options = [])
 {
     if ((isset($_REQUEST[$name]) and $_REQUEST[$name] == $value) or
-        (!isset($_REQUEST[$name]) and $default))
-    {
-        $options = array_merge(array('checked' => 'checked'), $options);
+        (!isset($_REQUEST[$name]) and $default)) {
+        $options = array_merge(['checked' => 'checked'], $options);
     }
-    $options = array_merge(array('id' => $name.'_'.$value), $options);
+    $options = array_merge(['id' => $name.'_'.$value], $options);
+
     return input_tag('radio', $name, $value, $options);
 }
 
-function check_box_tag($name, $value = '1', $default = false, $options = array())
+function check_box_tag($name, $value = '1', $default = false, $options = [])
 {
     if ((isset($_REQUEST[$name]) and $_REQUEST[$name] == $value) or
-        (!isset($_REQUEST['submit']) and $default))
-    {
-        $options = array_merge(array('checked' => 'checked'),$options);
+        (!isset($_REQUEST['submit']) and $default)) {
+        $options = array_merge(['checked' => 'checked'], $options);
     }
+
     return input_tag('checkbox', $name, $value, $options);
 }
 
-function submit_tag($name = '', $value = 'Submit', $options = array())
+function submit_tag($name = '', $value = 'Submit', $options = [])
 {
     return input_tag('submit', $name, $value, $options);
 }
 
-function reset_tag($name = '', $value = 'Reset', $options = array())
+function reset_tag($name = '', $value = 'Reset', $options = [])
 {
     return input_tag('reset', $name, $value, $options);
 }
 
-function label_tag($name, $text = null, $options = array())
+function label_tag($name, $text = null, $options = [])
 {
-    if ($text == null) {
+    if (null == $text) {
         $text = ucwords(str_replace('_', ' ', $name)).': ';
     }
     $options = array_merge(
-        array('for' => $name, 'id' => "label_for_$name"),
+        ['for' => $name, 'id' => "label_for_$name"],
         $options
     );
+
     return content_tag('label', $text, $options);
 }
 
-function labeled_text_field_tag($name, $default = null, $options = array())
+function labeled_text_field_tag($name, $default = null, $options = [])
 {
     return label_tag($name).text_field_tag($name, $default, $options);
 }
 
-function select_tag($name, $options, $default = null, $html_options = array())
+function select_tag($name, $options, $default = null, $html_options = [])
 {
     $opts = '';
     foreach ($options as $key => $value) {
-        $arr = array('value' => $value);
+        $arr = ['value' => $value];
         if ((isset($_REQUEST[$name]) and $_REQUEST[$name] == $value) or
-            (!isset($_REQUEST[$name]) and $default == $value))
-        {
-            $arr = array_merge(array('selected' => 'selected'),$arr);
+            (!isset($_REQUEST[$name]) and $default == $value)) {
+            $arr = array_merge(['selected' => 'selected'], $arr);
         }
         $opts .= content_tag('option', $key, $arr);
     }
     $html_options = array_merge(
-        array('name' => $name, 'id' => $name),
+        ['name' => $name, 'id' => $name],
         $html_options
     );
-    return "<select".tag_options($html_options).">$opts</select>";
+
+    return '<select'.tag_options($html_options).">$opts</select>";
 }
 
-function form_tag($uri = null, $options = array())
+function form_tag($uri = null, $options = [])
 {
-    if ($uri == null) {
+    if (null == $uri) {
         $uri = $_SERVER['PHP_SELF'];
     }
     $options = array_merge(
-        array('method' => 'get', 'action' => $uri),
+        ['method' => 'get', 'action' => $uri],
         $options
     );
+
     return tag('form', $options, true);
 }
 
 function form_end_tag()
 {
-    return "</form>";
+    return '</form>';
 }

--- a/examples/httpget.php
+++ b/examples/httpget.php
@@ -6,21 +6,19 @@
      * It demonstrates setting Accept headers and displays the response
      * headers and body.
      *
-     * @package    EasyRdf
      * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
      * @license    http://unlicense.org/
      */
+    require_once realpath(__DIR__.'/..').'/vendor/autoload.php';
+    require_once __DIR__.'/html_tag_helpers.php';
 
-    require_once realpath(__DIR__.'/..')."/vendor/autoload.php";
-    require_once __DIR__."/html_tag_helpers.php";
-
-    $accept_options = array(
+    $accept_options = [
       'text/html' => 'text/html',
       'application/rdf+xml' => 'application/rdf+xml',
       'application/xhtml+xml' => 'application/xhtml+xml',
       'application/json' => 'application/json',
       'text/turtle' => 'text/turtle',
-    );
+    ];
 ?>
 <html>
 <head>
@@ -36,43 +34,39 @@
 </head>
 <body>
 <h1>Test EasyRdf\HTTP\Client Get</h1>
-<?= form_tag() ?>
-<?= text_field_tag('uri', 'http://tomheath.com/id/me', array('size'=>50)) ?><br />
-<?= label_tag('accept', 'Accept Header: ').select_tag('accept',$accept_options) ?>
-<?= submit_tag() ?>
-<?= form_end_tag() ?>
+<?= form_tag(); ?>
+<?= text_field_tag('uri', 'http://tomheath.com/id/me', ['size' => 50]); ?><br />
+<?= label_tag('accept', 'Accept Header: ').select_tag('accept', $accept_options); ?>
+<?= submit_tag(); ?>
+<?= form_end_tag(); ?>
 
 <?php
     if (isset($_REQUEST['uri'])) {
         $client = new \EasyRdf\Http\Client($_REQUEST['uri']);
-        $client->setHeaders('Accept',$_REQUEST['accept']);
-        $response = $client->request();
-
-?>
+        $client->setHeaders('Accept', $_REQUEST['accept']);
+        $response = $client->request(); ?>
 
     <p class="status">
-    <b>Status</b>: <?= $response->getStatus() ?><br />
-    <b>Message</b>: <?= $response->getMessage() ?><br />
-    <b>Version</b>: HTTP/<?= $response->getVersion() ?><br />
+    <b>Status</b>: <?= $response->getStatus(); ?><br />
+    <b>Message</b>: <?= $response->getMessage(); ?><br />
+    <b>Version</b>: HTTP/<?= $response->getVersion(); ?><br />
     </p>
 
     <p class="headers">
     <?php
         foreach ($response->getHeaders() as $name => $value) {
             echo "<b>$name</b>: $value<br />\n";
-        }
-    ?>
+        } ?>
     </p>
 
     <p class="body">
       <?php
         if (defined('ENT_SUBSTITUTE')) {
             // This is needed for PHP 5.4+
-            print nl2br(htmlentities($response->getBody(), ENT_SUBSTITUTE | ENT_QUOTES));
+            echo nl2br(htmlentities($response->getBody(), ENT_SUBSTITUTE | ENT_QUOTES));
         } else {
-            print nl2br(htmlentities($response->getBody()));
-        }
-      ?>
+            echo nl2br(htmlentities($response->getBody()));
+        } ?>
     </p>
 
 <?php

--- a/examples/parse_rss.php
+++ b/examples/parse_rss.php
@@ -15,13 +15,11 @@
      * Note that this example only works with RSS 1.0 and no
      * other version (0.90, 1.1 and 2.0) as they are not RDF.
      *
-     * @package    EasyRdf
      * @copyright  Copyright (c) 2013 Nicholas J Humfrey
      * @license    http://unlicense.org/
      */
-
-    require_once realpath(__DIR__.'/..')."/vendor/autoload.php";
-    require_once __DIR__."/html_tag_helpers.php";
+    require_once realpath(__DIR__.'/..').'/vendor/autoload.php';
+    require_once __DIR__.'/html_tag_helpers.php';
 ?>
 <html>
 <head>
@@ -31,24 +29,24 @@
 <body>
 <h1>EasyRdf RSS 1.0 Parsing example</h1>
 
-<?= form_tag() ?>
-<?= text_field_tag('uri', 'http://planetrdf.com/index.rdf', array('size'=>50)) ?>
-<?= submit_tag() ?>
-<?= form_end_tag() ?>
+<?= form_tag(); ?>
+<?= text_field_tag('uri', 'http://planetrdf.com/index.rdf', ['size' => 50]); ?>
+<?= submit_tag(); ?>
+<?= form_end_tag(); ?>
 
 <?php
     if (isset($_REQUEST['uri'])) {
         $graph = \EasyRdf\Graph::newAndLoad($_REQUEST['uri'], 'rdfxml');
         $channel = $graph->get('rss:channel', '^rdf:type');
 
-        print "<p>Channel: ".link_to($channel->label(), $channel->get('rss:link'))."</p>\n";
-        print "<p>Description: ".$channel->get('rss:description')."</p>\n";
+        echo '<p>Channel: '.link_to($channel->label(), $channel->get('rss:link'))."</p>\n";
+        echo '<p>Description: '.$channel->get('rss:description')."</p>\n";
 
-        print "<ol>\n";
-        foreach($channel->get('rss:items') as $item) {
-            print "<li>".link_to($item->get('rss:title'), $item)."</li>\n";
+        echo "<ol>\n";
+        foreach ($channel->get('rss:items') as $item) {
+            echo '<li>'.link_to($item->get('rss:title'), $item)."</li>\n";
         }
-        print "</ol>\n";
+        echo "</ol>\n";
     }
 ?>
 </body>

--- a/examples/serialise.php
+++ b/examples/serialise.php
@@ -5,12 +5,10 @@
      * This example create a simple FOAF graph in memory and then
      * serialises it to the page in the format of choice.
      *
-     * @package    EasyRdf
      * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
      * @license    http://unlicense.org/
      */
-
-    require_once realpath(__DIR__.'/..')."/vendor/autoload.php";
+    require_once realpath(__DIR__.'/..').'/vendor/autoload.php';
 
     $graph = new \EasyRdf\Graph();
     $me = $graph->resource('http://www.example.com/joe#me', 'foaf:Person');
@@ -43,10 +41,10 @@
     foreach (\EasyRdf\Format::getFormats() as $f) {
         if ($f->getSerialiserClass()) {
             if ($f->getName() == $format) {
-                print "<li><b>".$f->getLabel()."</b></li>\n";
+                echo '<li><b>'.$f->getLabel()."</b></li>\n";
             } else {
-                print "<li><a href='?format=$f'>";
-                print $f->getLabel()."</a></li>\n";
+                echo "<li><a href='?format=$f'>";
+                echo $f->getLabel()."</a></li>\n";
             }
         }
     }
@@ -59,7 +57,7 @@
     if (!is_scalar($data)) {
         $data = var_export($data, true);
     }
-    print htmlspecialchars($data);
+    echo htmlspecialchars($data);
 ?>
 </pre>
 

--- a/examples/sparql_queryform.php
+++ b/examples/sparql_queryform.php
@@ -12,13 +12,11 @@
      * statements will automatically be added to the start of the query
      * string.
      *
-     * @package    EasyRdf
      * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
      * @license    http://unlicense.org/
      */
-
-    require_once realpath(__DIR__.'/..')."/vendor/autoload.php";
-    require_once __DIR__."/html_tag_helpers.php";
+    require_once realpath(__DIR__.'/..').'/vendor/autoload.php';
+    require_once __DIR__.'/html_tag_helpers.php';
 
     if (isset($_REQUEST['query'])) {
         $_REQUEST['query'] = stripslashes($_REQUEST['query']);
@@ -42,18 +40,18 @@
 
 <div style="margin: 0.5em">
   <?php
-    print form_tag();
-    print label_tag('endpoint');
-    print text_field_tag('endpoint', "http://dbpedia.org/sparql", array('size'=>80)).'<br />';
-    print "<code>";
-    foreach(\EasyRdf\RdfNamespace::namespaces() as $prefix => $uri) {
-        print "PREFIX $prefix: &lt;".htmlspecialchars($uri)."&gt;<br />\n";
+    echo form_tag();
+    echo label_tag('endpoint');
+    echo text_field_tag('endpoint', 'http://dbpedia.org/sparql', ['size' => 80]).'<br />';
+    echo '<code>';
+    foreach (\EasyRdf\RdfNamespace::namespaces() as $prefix => $uri) {
+        echo "PREFIX $prefix: &lt;".htmlspecialchars($uri)."&gt;<br />\n";
     }
-    print "</code>";
-    print text_area_tag('query', "SELECT * WHERE {\n  ?s ?p ?o\n}\nLIMIT 10", array('rows' => 10, 'cols' => 80)).'<br />';
-    print check_box_tag('text') . label_tag('text', 'Plain text results').'<br />';
-    print reset_tag() . submit_tag();
-    print form_end_tag();
+    echo '</code>';
+    echo text_area_tag('query', "SELECT * WHERE {\n  ?s ?p ?o\n}\nLIMIT 10", ['rows' => 10, 'cols' => 80]).'<br />';
+    echo check_box_tag('text').label_tag('text', 'Plain text results').'<br />';
+    echo reset_tag().submit_tag();
+    echo form_end_tag();
   ?>
 </div>
 
@@ -63,12 +61,12 @@
       try {
           $results = $sparql->query($_REQUEST['query']);
           if (isset($_REQUEST['text'])) {
-              print "<pre>".htmlspecialchars($results->dump('text'))."</pre>";
+              echo '<pre>'.htmlspecialchars($results->dump('text')).'</pre>';
           } else {
-              print $results->dump('html');
+              echo $results->dump('html');
           }
       } catch (Exception $e) {
-          print "<div class='error'>".$e->getMessage()."</div>\n";
+          echo "<div class='error'>".$e->getMessage()."</div>\n";
       }
   }
 ?>

--- a/examples/uk_postcode.php
+++ b/examples/uk_postcode.php
@@ -6,13 +6,11 @@
      * loading RDF data from the web and then directly displaying
      * literals from the graph on the page.
      *
-     * @package    EasyRdf
      * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
      * @license    http://unlicense.org/
      */
-
-    require_once realpath(__DIR__.'/..')."/vendor/autoload.php";
-    require_once __DIR__."/html_tag_helpers.php";
+    require_once realpath(__DIR__.'/..').'/vendor/autoload.php';
+    require_once __DIR__.'/html_tag_helpers.php';
 
     \EasyRdf\RdfNamespace::set('postcode', 'http://data.ordnancesurvey.co.uk/ontology/postcode/');
     \EasyRdf\RdfNamespace::set('sr', 'http://data.ordnancesurvey.co.uk/ontology/spatialrelations/');
@@ -37,10 +35,10 @@
 <body>
 <h1>EasyRdf UK Postcode Resolver</h1>
 
-<?= form_tag() ?>
-  <?= text_field_tag('postcode', 'W1A 1AA', array('size'=>10)) ?>
-  <?= submit_tag() ?>
-<?= form_end_tag() ?>
+<?= form_tag(); ?>
+  <?= text_field_tag('postcode', 'W1A 1AA', ['size' => 10]); ?>
+  <?= submit_tag(); ?>
+<?= form_end_tag(); ?>
 
 <?php
     if (isset($_REQUEST['postcode'])) {
@@ -52,20 +50,20 @@
         $res = $graph->get('postcode:PostcodeUnit', '^rdf:type');
         if ($res) {
             $ll = $res->get('geo:lat').','.$res->get('geo:long');
-            print "<iframe id='map' width='500' height='250' frameborder='0' scrolling='no' src='http://maps.google.com/maps?q=$ll&amp;output=embed'></iframe>";
-            print "<table id='facts'>\n";
-            print "<tr><th>Longitude:</th><td>" . $res->get('geo:long') . "</td></tr>\n";
-            print "<tr><th>Latitude:</th><td>" . $res->get('geo:lat') . "</td></tr>\n";
-            print "<tr><th>Easting:</th><td>" . $res->get('sr:easting') . "</td></tr>\n";
-            print "<tr><th>Northing:</th><td>" . $res->get('sr:northing') . "</td></tr>\n";
-            print "<tr><th>District:</th><td>" . $res->get('postcode:district')->label() . "</td></tr>\n";
-            print "<tr><th>Ward:</th><td>" . $res->get('postcode:ward')->label() . "</td></tr>\n";
-            print "</table>\n";
+            echo "<iframe id='map' width='500' height='250' frameborder='0' scrolling='no' src='http://maps.google.com/maps?q=$ll&amp;output=embed'></iframe>";
+            echo "<table id='facts'>\n";
+            echo '<tr><th>Longitude:</th><td>'.$res->get('geo:long')."</td></tr>\n";
+            echo '<tr><th>Latitude:</th><td>'.$res->get('geo:lat')."</td></tr>\n";
+            echo '<tr><th>Easting:</th><td>'.$res->get('sr:easting')."</td></tr>\n";
+            echo '<tr><th>Northing:</th><td>'.$res->get('sr:northing')."</td></tr>\n";
+            echo '<tr><th>District:</th><td>'.$res->get('postcode:district')->label()."</td></tr>\n";
+            echo '<tr><th>Ward:</th><td>'.$res->get('postcode:ward')->label()."</td></tr>\n";
+            echo "</table>\n";
 
-            print "<div style='clear: both'></div>\n";
+            echo "<div style='clear: both'></div>\n";
         }
 
-        print $graph->dump();
+        echo $graph->dump();
     }
 ?>
 </body>

--- a/examples/zend_framework.php
+++ b/examples/zend_framework.php
@@ -9,21 +9,19 @@
      * and then fetches the data back using a SPARQL SELECT query.
      * Zend's curl HTTP client adaptor is used to perform the HTTP requests.
      *
-     * @package    EasyRdf
      * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
      * @license    http://unlicense.org/
      */
-
-    require_once realpath(__DIR__.'/..')."/vendor/autoload.php";
+    require_once realpath(__DIR__.'/..').'/vendor/autoload.php';
 
     // use the CURL based HTTP client adaptor
     $client = new \Zend\Http\Client(
         null,
-        array(
+        [
             'adapter' => 'Zend\Http\Client\Adapter\Curl',
             'keepalive' => true,
-            'useragent' => "EasyRdf/zendtest"
-        )
+            'useragent' => 'EasyRdf/zendtest',
+        ]
     );
     \EasyRdf\Http::setDefaultHttpClient($client);
 ?>
@@ -36,17 +34,17 @@
 <h1>Zend Framework Example</h1>
 
 <?php
-    # Load some sample data into a graph
+    // Load some sample data into a graph
     $graph = new \EasyRdf\Graph('http://example.com/joe');
     $joe = $graph->resource('http://example.com/joe#me', 'foaf:Person');
     $joe->add('foaf:name', 'Joe Bloggs');
     $joe->addResource('foaf:homepage', 'http://example.com/joe/');
 
-    # Store it in a local graphstore
+    // Store it in a local graphstore
     $store = new \EasyRdf\GraphStore('http://localhost:8080/data/');
     $store->replace($graph);
 
-    # Now make a query to the graphstore
+    // Now make a query to the graphstore
     $sparql = new \EasyRdf\Sparql\Client('http://localhost:8080/sparql/');
     $result = $sparql->query('SELECT * WHERE {<http://example.com/joe#me> ?p ?o}');
     echo $result->dump();

--- a/lib/Collection.php
+++ b/lib/Collection.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EasyRdf;
 
 /**
@@ -31,7 +32,6 @@ namespace EasyRdf;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
@@ -43,8 +43,8 @@ namespace EasyRdf;
  *
  * Note that items are numbered from 1 (not 0) for consistency with RDF Containers.
  *
- * @package    EasyRdf
- * @link       http://www.w3.org/TR/xmlschema-2/#date
+ * @see       http://www.w3.org/TR/xmlschema-2/#date
+ *
  * @copyright  Copyright (c) 2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
@@ -68,27 +68,23 @@ class Collection extends Resource implements \ArrayAccess, \Countable, \Seekable
      *
      * The first item is postion 1
      *
-     * @param  integer  $position     The position in the container to seek to
+     * @param int $position The position in the container to seek to
      *
      * @throws \OutOfBoundsException
      * @throws \InvalidArgumentException
      */
     public function seek($position)
     {
-        if (is_int($position) and $position > 0) {
+        if (\is_int($position) and $position > 0) {
             list($node, $actual) = $this->getCollectionNode($position);
             if ($actual === $position) {
                 $this->position = $actual;
                 $this->current = $node;
             } else {
-                throw new \OutOfBoundsException(
-                    "Unable to seek to position $position in the collection"
-                );
+                throw new \OutOfBoundsException("Unable to seek to position $position in the collection");
             }
         } else {
-            throw new \InvalidArgumentException(
-                "Collection position must be a positive integer"
-            );
+            throw new \InvalidArgumentException('Collection position must be a positive integer');
         }
     }
 
@@ -107,7 +103,7 @@ class Collection extends Resource implements \ArrayAccess, \Countable, \Seekable
      */
     public function current()
     {
-        if ($this->position === 1) {
+        if (1 === $this->position) {
             return $this->get('rdf:first');
         } elseif ($this->current) {
             return $this->current->get('rdf:first');
@@ -130,12 +126,12 @@ class Collection extends Resource implements \ArrayAccess, \Countable, \Seekable
      */
     public function next()
     {
-        if ($this->position === 1) {
+        if (1 === $this->position) {
             $this->current = $this->get('rdf:rest');
         } elseif ($this->current) {
             $this->current = $this->current->get('rdf:rest');
         }
-        $this->position++;
+        ++$this->position;
     }
 
     /** Checks if current position is valid
@@ -144,9 +140,9 @@ class Collection extends Resource implements \ArrayAccess, \Countable, \Seekable
      */
     public function valid()
     {
-        if ($this->position === 1 and $this->hasProperty('rdf:first')) {
+        if (1 === $this->position and $this->hasProperty('rdf:first')) {
             return true;
-        } elseif ($this->current !== null and $this->current->hasProperty('rdf:first')) {
+        } elseif (null !== $this->current and $this->current->hasProperty('rdf:first')) {
             return true;
         } else {
             return false;
@@ -162,20 +158,21 @@ class Collection extends Resource implements \ArrayAccess, \Countable, \Seekable
      * If the offset is null, then the last node in the
      * collection (before rdf:nil) will be returned.
      *
-     * @param  integer $offset          The offset into the collection (or null)
+     * @param int $offset The offset into the collection (or null)
      *
-     * @return array   $node, $postion  The node object and postion of the node
+     * @return array $node, $postion  The node object and postion of the node
      */
     public function getCollectionNode($offset)
     {
         $position = 1;
         $node = $this;
         $nil = $this->graph->resource('rdf:nil');
-        while (($rest = $node->get('rdf:rest')) and $rest !== $nil and (is_null($offset) or ($position < $offset))) {
+        while (($rest = $node->get('rdf:rest')) and $rest !== $nil and (null === $offset or ($position < $offset))) {
             $node = $rest;
-            $position++;
+            ++$position;
         }
-        return array($node, $position);
+
+        return [$node, $position];
     }
 
     /** Counts the number of items in the collection
@@ -183,7 +180,7 @@ class Collection extends Resource implements \ArrayAccess, \Countable, \Seekable
      * Note that this is an slow method - it is more efficient to use
      * the iterator interface, if you can.
      *
-     * @return integer The number of items in the collection
+     * @return int The number of items in the collection
      */
     public function count()
     {
@@ -198,17 +195,17 @@ class Collection extends Resource implements \ArrayAccess, \Countable, \Seekable
 
     /** Append an item to the end of the collection
      *
-     * @param  mixed $value      The value to append
+     * @param mixed $value The value to append
      *
-     * @return integer           The number of values appended (1 or 0)
+     * @return int The number of values appended (1 or 0)
      */
     public function append($value)
     {
         // Find the end of the collection
-        list($node, ) = $this->getCollectionNode(null);
+        list($node) = $this->getCollectionNode(null);
         $rest = $node->get('rdf:rest');
 
-        if ($node === $this and is_null($rest)) {
+        if ($node === $this and null === $rest) {
             $node->set('rdf:first', $value);
             $node->addResource('rdf:rest', 'rdf:nil');
         } else {
@@ -227,13 +224,12 @@ class Collection extends Resource implements \ArrayAccess, \Countable, \Seekable
      */
     public function offsetExists($offset)
     {
-        if (is_int($offset) and $offset > 0) {
+        if (\is_int($offset) and $offset > 0) {
             list($node, $position) = $this->getCollectionNode($offset);
-            return ($node and $position === $offset and $node->hasProperty('rdf:first'));
+
+            return $node and $position === $offset and $node->hasProperty('rdf:first');
         } else {
-            throw new \InvalidArgumentException(
-                "Collection offset must be a positive integer"
-            );
+            throw new \InvalidArgumentException('Collection offset must be a positive integer');
         }
     }
 
@@ -243,15 +239,13 @@ class Collection extends Resource implements \ArrayAccess, \Countable, \Seekable
      */
     public function offsetGet($offset)
     {
-        if (is_int($offset) and $offset > 0) {
+        if (\is_int($offset) and $offset > 0) {
             list($node, $position) = $this->getCollectionNode($offset);
             if ($node and $position === $offset) {
                 return $node->get('rdf:first');
             }
         } else {
-            throw new \InvalidArgumentException(
-                "Collection offset must be a positive integer"
-            );
+            throw new \InvalidArgumentException('Collection offset must be a positive integer');
         }
     }
 
@@ -262,10 +256,10 @@ class Collection extends Resource implements \ArrayAccess, \Countable, \Seekable
      */
     public function offsetSet($offset, $value)
     {
-        if (is_null($offset)) {
+        if (null === $offset) {
             // No offset - append to end of collection
             $this->append($value);
-        } elseif (is_int($offset) and $offset > 0) {
+        } elseif (\is_int($offset) and $offset > 0) {
             list($node, $position) = $this->getCollectionNode($offset);
 
             // Create nodes, if they are missing
@@ -274,7 +268,7 @@ class Collection extends Resource implements \ArrayAccess, \Countable, \Seekable
                 $node->set('rdf:rest', $new);
                 $new->addResource('rdf:rest', 'rdf:nil');
                 $node = $new;
-                $position++;
+                ++$position;
             }
 
             // Terminate the list
@@ -284,9 +278,7 @@ class Collection extends Resource implements \ArrayAccess, \Countable, \Seekable
 
             return $node->set('rdf:first', $value);
         } else {
-            throw new \InvalidArgumentException(
-                "Collection offset must be a positive integer"
-            );
+            throw new \InvalidArgumentException('Collection offset must be a positive integer');
         }
     }
 
@@ -297,18 +289,16 @@ class Collection extends Resource implements \ArrayAccess, \Countable, \Seekable
      */
     public function offsetUnset($offset)
     {
-        if (is_int($offset) and $offset > 0) {
+        if (\is_int($offset) and $offset > 0) {
             list($node, $position) = $this->getCollectionNode($offset);
         } else {
-            throw new \InvalidArgumentException(
-                "Collection offset must be a positive integer"
-            );
+            throw new \InvalidArgumentException('Collection offset must be a positive integer');
         }
 
         // Does the item exist?
         if ($node and $position === $offset) {
             $nil = $this->graph->resource('rdf:nil');
-            if ($position === 1) {
+            if (1 === $position) {
                 $rest = $node->get('rdf:rest');
                 if ($rest and $rest !== $nil) {
                     // Move second value, so we can keep the head of list
@@ -326,7 +316,7 @@ class Collection extends Resource implements \ArrayAccess, \Countable, \Seekable
                 $node->delete('rdf:first');
                 $rest = $node->get('rdf:rest');
                 $previous = $node->get('^rdf:rest');
-                if (is_null($rest)) {
+                if (null === $rest) {
                     $rest = $nil;
                 }
                 if ($previous) {

--- a/lib/Container.php
+++ b/lib/Container.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EasyRdf;
 
 /**
@@ -31,7 +32,6 @@ namespace EasyRdf;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
@@ -42,8 +42,8 @@ namespace EasyRdf;
  *
  * This class can be used to iterate through a list of items.
  *
- * @package    EasyRdf
- * @link       http://www.w3.org/TR/xmlschema-2/#date
+ * @see       http://www.w3.org/TR/xmlschema-2/#date
+ *
  * @copyright  Copyright (c) 2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
@@ -65,25 +65,21 @@ class Container extends Resource implements \ArrayAccess, \Countable, \SeekableI
      *
      * The first item is postion 1
      *
-     * @param  integer  $position     The position in the container to seek to
+     * @param int $position The position in the container to seek to
      *
      * @throws \OutOfBoundsException
      * @throws \InvalidArgumentException
      */
     public function seek($position)
     {
-        if (is_int($position) and $position > 0) {
+        if (\is_int($position) and $position > 0) {
             if ($this->hasProperty('rdf:_'.$position)) {
                 $this->position = $position;
             } else {
-                throw new \OutOfBoundsException(
-                    "Unable to seek to position $position in the container"
-                );
+                throw new \OutOfBoundsException("Unable to seek to position $position in the container");
             }
         } else {
-            throw new \InvalidArgumentException(
-                "Container position must be a positive integer"
-            );
+            throw new \InvalidArgumentException('Container position must be a positive integer');
         }
     }
 
@@ -118,7 +114,7 @@ class Container extends Resource implements \ArrayAccess, \Countable, \SeekableI
      */
     public function next()
     {
-        $this->position++;
+        ++$this->position;
     }
 
     /** Checks if current position is valid
@@ -135,29 +131,30 @@ class Container extends Resource implements \ArrayAccess, \Countable, \SeekableI
      * Note that this is an slow method - it is more efficient to use
      * the iterator interface, if you can.
      *
-     * @return integer The number of items in the container
+     * @return int The number of items in the container
      */
     public function count()
     {
         $pos = 1;
         while ($this->hasProperty('rdf:_'.$pos)) {
-            $pos++;
+            ++$pos;
         }
+
         return $pos - 1;
     }
 
     /** Append an item to the end of the container
      *
-     * @param  mixed $value      The value to append
+     * @param mixed $value The value to append
      *
-     * @return integer           The number of values appended (1 or 0)
+     * @return int The number of values appended (1 or 0)
      */
     public function append($value)
     {
         // Find the end of the list
         $pos = 1;
         while ($this->hasProperty('rdf:_'.$pos)) {
-            $pos++;
+            ++$pos;
         }
 
         // Add the item
@@ -170,12 +167,10 @@ class Container extends Resource implements \ArrayAccess, \Countable, \SeekableI
      */
     public function offsetExists($offset)
     {
-        if (is_int($offset) and $offset > 0) {
+        if (\is_int($offset) and $offset > 0) {
             return $this->hasProperty('rdf:_'.$offset);
         } else {
-            throw new \InvalidArgumentException(
-                "Container position must be a positive integer"
-            );
+            throw new \InvalidArgumentException('Container position must be a positive integer');
         }
     }
 
@@ -185,12 +180,10 @@ class Container extends Resource implements \ArrayAccess, \Countable, \SeekableI
      */
     public function offsetGet($offset)
     {
-        if (is_int($offset) and $offset > 0) {
+        if (\is_int($offset) and $offset > 0) {
             return $this->get('rdf:_'.$offset);
         } else {
-            throw new \InvalidArgumentException(
-                "Container position must be a positive integer"
-            );
+            throw new \InvalidArgumentException('Container position must be a positive integer');
         }
     }
 
@@ -203,14 +196,12 @@ class Container extends Resource implements \ArrayAccess, \Countable, \SeekableI
      */
     public function offsetSet($offset, $value)
     {
-        if (is_int($offset) and $offset > 0) {
+        if (\is_int($offset) and $offset > 0) {
             return $this->set('rdf:_'.$offset, $value);
-        } elseif (is_null($offset)) {
+        } elseif (null === $offset) {
             return $this->append($value);
         } else {
-            throw new \InvalidArgumentException(
-                "Container position must be a positive integer"
-            );
+            throw new \InvalidArgumentException('Container position must be a positive integer');
         }
     }
 
@@ -223,12 +214,10 @@ class Container extends Resource implements \ArrayAccess, \Countable, \SeekableI
      */
     public function offsetUnset($offset)
     {
-        if (is_int($offset) and $offset > 0) {
+        if (\is_int($offset) and $offset > 0) {
             return $this->delete('rdf:_'.$offset);
         } else {
-            throw new \InvalidArgumentException(
-                "Container position must be a positive integer"
-            );
+            throw new \InvalidArgumentException('Container position must be a positive integer');
         }
     }
 }

--- a/lib/Exception.php
+++ b/lib/Exception.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EasyRdf;
 
 /**
@@ -31,7 +32,6 @@ namespace EasyRdf;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
@@ -41,7 +41,6 @@ namespace EasyRdf;
  *
  * All exceptions thrown by EasyRdf are an instance of this class.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */

--- a/lib/Format.php
+++ b/lib/Format.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EasyRdf;
 
 /**
@@ -31,7 +32,6 @@ namespace EasyRdf;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
@@ -43,25 +43,24 @@ namespace EasyRdf;
  * stored. A single parser and serialiser can also be registered to each
  * format.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
 class Format
 {
-    private static $formats = array();
+    private static $formats = [];
 
-    private $name = array();
+    private $name = [];
     private $label = null;
     private $uri = null;
-    private $mimeTypes = array();
-    private $extensions = array();
+    private $mimeTypes = [];
+    private $extensions = [];
     private $parserClass = null;
     private $serialiserClass = null;
 
     /** Get a list of format names
      *
-     * @return array          An array of formats name
+     * @return array An array of formats name
      */
     public static function getNames()
     {
@@ -70,7 +69,7 @@ class Format
 
     /** Get a list of all the registered formats
      *
-     * @return array          An array of format objects
+     * @return array An array of format objects
      */
     public static function getFormats()
     {
@@ -87,15 +86,15 @@ class Format
      * q value for that type. The types are sorted by q value
      * before constructing the string.
      *
-     * @param array $extraTypes    extra MIME types to add
+     * @param array $extraTypes extra MIME types to add
      *
-     * @return string              list of supported MIME types
+     * @return string list of supported MIME types
      */
-    public static function getHttpAcceptHeader(array $extraTypes = array())
+    public static function getHttpAcceptHeader(array $extraTypes = [])
     {
         $accept = $extraTypes;
         foreach (self::$formats as $format) {
-            if ($format->parserClass and count($format->mimeTypes) > 0) {
+            if ($format->parserClass and \count($format->mimeTypes) > 0) {
                 $accept = array_merge($accept, $format->mimeTypes);
             }
         }
@@ -105,7 +104,7 @@ class Format
 
     /**
      * Convert array of types to Accept header value
-     * @param array $accepted_types
+     *
      * @return string
      */
     public static function formatAcceptHeader(array $accepted_types)
@@ -117,10 +116,10 @@ class Format
             if ($acceptStr) {
                 $acceptStr .= ',';
             }
-            if ($q == 1.0) {
+            if (1.0 == $q) {
                 $acceptStr .= $type;
             } else {
-                $acceptStr .= sprintf("%s;q=%1.1F", $type, $q);
+                $acceptStr .= sprintf('%s;q=%1.1F', $type, $q);
             }
         }
 
@@ -129,44 +128,41 @@ class Format
 
     /** Check if a named graph exists
      *
-     * @param string $name    the name of the format
+     * @param string $name the name of the format
      *
-     * @return boolean        true if the format exists
+     * @return bool true if the format exists
      */
     public static function formatExists($name)
     {
-        return array_key_exists($name, self::$formats);
+        return \array_key_exists($name, self::$formats);
     }
 
     /** Get a EasyRdf\Format from a name, uri or mime type
      *
-     * @param string $query  a query string to search for
+     * @param string $query a query string to search for
      *
-     * @return self  the first object that matches the query
+     * @return self the first object that matches the query
+     *
      * @throws \InvalidArgumentException
-     * @throws Exception  if no format is found
+     * @throws Exception                 if no format is found
      */
     public static function getFormat($query)
     {
-        if (!is_string($query) or $query == null or $query == '') {
-            throw new \InvalidArgumentException(
-                "\$query should be a string and cannot be null or empty"
-            );
+        if (!\is_string($query) or null == $query or '' == $query) {
+            throw new \InvalidArgumentException('$query should be a string and cannot be null or empty');
         }
 
         foreach (self::$formats as $format) {
             if ($query == $format->name or
                 $query == $format->uri or
-                array_key_exists($query, $format->mimeTypes) or
-                in_array($query, $format->extensions)) {
+                \array_key_exists($query, $format->mimeTypes) or
+                \in_array($query, $format->extensions)) {
                 return $format;
             }
         }
 
-        # No match
-        throw new Exception(
-            "Format is not recognised: $query"
-        );
+        // No match
+        throw new Exception("Format is not recognised: $query");
     }
 
     /** Register a new format
@@ -178,22 +174,21 @@ class Format
      * @param array|string $extensions One or more extensions (file suffix)
      *
      * @throws \InvalidArgumentException
-     * @return self  New Format object
+     *
+     * @return self New Format object
      */
     public static function register(
         $name,
         $label = null,
         $uri = null,
-        $mimeTypes = array(),
-        $extensions = array()
+        $mimeTypes = [],
+        $extensions = []
     ) {
-        if (!is_string($name) or $name == null or $name == '') {
-            throw new \InvalidArgumentException(
-                "\$name should be a string and cannot be null or empty"
-            );
+        if (!\is_string($name) or null == $name or '' == $name) {
+            throw new \InvalidArgumentException('$name should be a string and cannot be null or empty');
         }
 
-        if (!array_key_exists($name, self::$formats)) {
+        if (!\array_key_exists($name, self::$formats)) {
             self::$formats[$name] = new self($name);
         }
 
@@ -201,12 +196,13 @@ class Format
         self::$formats[$name]->setUri($uri);
         self::$formats[$name]->setMimeTypes($mimeTypes);
         self::$formats[$name]->setExtensions($extensions);
+
         return self::$formats[$name];
     }
 
     /** Remove a format from the registry
      *
-     * @param  string  $name      The name of the format (e.g. ntriples)
+     * @param string $name The name of the format (e.g. ntriples)
      */
     public static function unregister($name)
     {
@@ -215,8 +211,8 @@ class Format
 
     /** Class method to register a parser class to a format name
      *
-     * @param  string  $name   The name of the format (e.g. ntriples)
-     * @param  string  $class  The name of the class (e.g. EasyRdf\Parser\Ntriples)
+     * @param string $name  The name of the format (e.g. ntriples)
+     * @param string $class The name of the class (e.g. EasyRdf\Parser\Ntriples)
      */
     public static function registerParser($name, $class)
     {
@@ -228,8 +224,8 @@ class Format
 
     /** Class method to register a serialiser class to a format name
      *
-     * @param  string  $name   The name of the format (e.g. ntriples)
-     * @param  string  $class  The name of the class (e.g. EasyRdf\Serialiser\Ntriples)
+     * @param string $name  The name of the format (e.g. ntriples)
+     * @param string $class The name of the class (e.g. EasyRdf\Serialiser\Ntriples)
      */
     public static function registerSerialiser($name, $class)
     {
@@ -245,22 +241,22 @@ class Format
      *
      * If the document format is not recognised, null is returned.
      *
-     * @param string  $data     The document data
-     * @param string  $filename Optional filename
+     * @param string $data     The document data
+     * @param string $filename Optional filename
      *
-     * @return self  New format object
+     * @return self New format object
      */
     public static function guessFormat($data, $filename = null)
     {
-        if (is_array($data)) {
-            # Data has already been parsed into RDF/PHP
+        if (\is_array($data)) {
+            // Data has already been parsed into RDF/PHP
             return self::getFormat('php');
         }
 
         // First try and identify by the filename
         if ($filename and preg_match('/\.(\w+)$/', $filename, $matches)) {
             foreach (self::$formats as $format) {
-                if (in_array($matches[1], $format->extensions)) {
+                if (\in_array($matches[1], $format->extensions)) {
                     return $format;
                 }
             }
@@ -277,7 +273,7 @@ class Format
         } elseif (preg_match('/\WRDFa\W/i', $short)) {
             return self::getFormat('rdfa');
         } elseif (preg_match('/<!DOCTYPE html|<html/i', $short)) {
-            # We don't support any other microformats embedded in HTML
+            // We don't support any other microformats embedded in HTML
             return self::getFormat('rdfa');
         } elseif (preg_match('/@prefix\s|@base\s/', $short)) {
             return self::getFormat('turtle');
@@ -294,14 +290,15 @@ class Format
      * This constructor is for internal use only.
      * To create a new format, use the register method.
      *
-     * @param  string  $name    The name of the format
+     * @param string $name The name of the format
+     *
      * @see    Format::register()
      * @ignore
      */
     public function __construct($name)
     {
         $this->name = $name;
-        $this->label = $name;  # Only a default
+        $this->label = $name;  // Only a default
     }
 
     /** Get the name of a format object
@@ -324,19 +321,19 @@ class Format
 
     /** Set the label for a format object
      *
-     * @param  string $label  The new label for the format
+     * @param string $label The new label for the format
      *
      * @throws \InvalidArgumentException
+     *
      * @return string|null
      */
     public function setLabel($label)
     {
         if ($label) {
-            if (!is_string($label)) {
-                throw new \InvalidArgumentException(
-                    "\$label should be a string"
-                );
+            if (!\is_string($label)) {
+                throw new \InvalidArgumentException('$label should be a string');
             }
+
             return $this->label = $label;
         } else {
             return $this->label = null;
@@ -354,19 +351,19 @@ class Format
 
     /** Set the URI for a format object
      *
-     * @param string $uri  The new URI for the format
+     * @param string $uri The new URI for the format
      *
      * @throws \InvalidArgumentException
+     *
      * @return string|null
      */
     public function setUri($uri)
     {
         if ($uri) {
-            if (!is_string($uri)) {
-                throw new \InvalidArgumentException(
-                    "\$uri should be a string"
-                );
+            if (!\is_string($uri)) {
+                throw new \InvalidArgumentException('$uri should be a string');
             }
+
             return $this->uri = $uri;
         } else {
             return $this->uri = null;
@@ -375,7 +372,7 @@ class Format
 
     /** Get the default registered mime type for a format object
      *
-     * @return string The default mime type as a string.
+     * @return string the default mime type as a string
      */
     public function getDefaultMimeType()
     {
@@ -397,23 +394,23 @@ class Format
 
     /** Set the MIME Types for a format object
      *
-     * @param string|array $mimeTypes  One or more mime types
+     * @param string|array $mimeTypes One or more mime types
      */
     public function setMimeTypes($mimeTypes)
     {
         if ($mimeTypes) {
-            if (!is_array($mimeTypes)) {
-                $mimeTypes = array($mimeTypes);
+            if (!\is_array($mimeTypes)) {
+                $mimeTypes = [$mimeTypes];
             }
             $this->mimeTypes = $mimeTypes;
         } else {
-            $this->mimeTypes = array();
+            $this->mimeTypes = [];
         }
     }
 
     /** Get the default registered file extension (filename suffix) for a format object
      *
-     * @return string The default extension as a string.
+     * @return string the default extension as a string
      */
     public function getDefaultExtension()
     {
@@ -433,33 +430,31 @@ class Format
 
     /** Set the file format extensions (filename suffix) for a format object
      *
-     * @param mixed $extensions  One or more file extensions
+     * @param mixed $extensions One or more file extensions
      */
     public function setExtensions($extensions)
     {
         if ($extensions) {
-            if (!is_array($extensions)) {
-                $extensions = array($extensions);
+            if (!\is_array($extensions)) {
+                $extensions = [$extensions];
             }
             $this->extensions = $extensions;
         } else {
-            $this->extensions = array();
+            $this->extensions = [];
         }
     }
 
     /** Set the parser to use for a format
      *
-     * @param string $class  The name of the class
+     * @param string $class The name of the class
      *
      * @throws \InvalidArgumentException
      */
     public function setParserClass($class)
     {
         if ($class) {
-            if (!is_string($class)) {
-                throw new \InvalidArgumentException(
-                    "\$class should be a string"
-                );
+            if (!\is_string($class)) {
+                throw new \InvalidArgumentException('$class should be a string');
             }
             $this->parserClass = $class;
         } else {
@@ -479,32 +474,30 @@ class Format
     /** Create a new parser to parse this format
      *
      * @throws Exception
+     *
      * @return object The new parser object
      */
     public function newParser()
     {
         $parserClass = $this->parserClass;
         if (!$parserClass) {
-            throw new Exception(
-                "No parser class available for format: ".$this->getName()
-            );
+            throw new Exception('No parser class available for format: '.$this->getName());
         }
-        return (new $parserClass());
+
+        return new $parserClass();
     }
 
     /** Set the serialiser to use for a format
      *
-     * @param string $class  The name of the class
+     * @param string $class The name of the class
      *
      * @throws \InvalidArgumentException
      */
     public function setSerialiserClass($class)
     {
         if ($class) {
-            if (!is_string($class)) {
-                throw new \InvalidArgumentException(
-                    "\$class should be a string"
-                );
+            if (!\is_string($class)) {
+                throw new \InvalidArgumentException('$class should be a string');
             }
             $this->serialiserClass = $class;
         } else {
@@ -524,17 +517,17 @@ class Format
     /** Create a new serialiser to parse this format
      *
      * @throws Exception
+     *
      * @return object The new serialiser object
      */
     public function newSerialiser()
     {
         $serialiserClass = $this->serialiserClass;
         if (!$serialiserClass) {
-            throw new Exception(
-                "No serialiser class available for format: ".$this->getName()
-            );
+            throw new Exception('No serialiser class available for format: '.$this->getName());
         }
-        return (new $serialiserClass());
+
+        return new $serialiserClass();
     }
 
     /** Magic method to return the name of the format when casted to string
@@ -547,7 +540,6 @@ class Format
     }
 }
 
-
 /*
    Register default set of supported formats
    NOTE: they are ordered by preference
@@ -557,78 +549,78 @@ Format::register(
     'php',
     'RDF/PHP',
     'http://n2.talis.com/wiki/RDF_PHP_Specification',
-    array(
-        'application/x-httpd-php-source' => 1.0
-    ),
-    array('phps')
+    [
+        'application/x-httpd-php-source' => 1.0,
+    ],
+    ['phps']
 );
 
 Format::register(
     'json',
     'RDF/JSON Resource-Centric',
     'http://n2.talis.com/wiki/RDF_JSON_Specification',
-    array(
+    [
         'application/json' => 1.0,
         'text/json' => 0.9,
-        'application/rdf+json' => 0.9
-    ),
-    array('json')
+        'application/rdf+json' => 0.9,
+    ],
+    ['json']
 );
 
 Format::register(
     'jsonld',
     'JSON-LD',
     'http://www.w3.org/TR/json-ld/',
-    array(
-        'application/ld+json' => 1.0
-    ),
-    array('jsonld')
+    [
+        'application/ld+json' => 1.0,
+    ],
+    ['jsonld']
 );
 
 Format::register(
     'ntriples',
     'N-Triples',
     'http://www.w3.org/TR/n-triples/',
-    array(
+    [
         'application/n-triples' => 1.0,
         'text/plain' => 0.9,
         'text/ntriples' => 0.9,
         'application/ntriples' => 0.9,
-        'application/x-ntriples' => 0.9
-    ),
-    array('nt')
+        'application/x-ntriples' => 0.9,
+    ],
+    ['nt']
 );
 
 Format::register(
     'turtle',
     'Turtle Terse RDF Triple Language',
     'http://www.dajobe.org/2004/01/turtle',
-    array(
+    [
         'text/turtle' => 0.8,
         'application/turtle' => 0.7,
-        'application/x-turtle' => 0.7
-    ),
-    array('ttl')
+        'application/x-turtle' => 0.7,
+    ],
+    ['ttl']
 );
 
 Format::register(
     'rdfxml',
     'RDF/XML',
     'http://www.w3.org/TR/rdf-syntax-grammar',
-    array(
-        'application/rdf+xml' => 0.8
-    ),
-    array('rdf', 'xrdf')
+    [
+        'application/rdf+xml' => 0.8,
+    ],
+    ['rdf', 'xrdf']
 );
 
 Format::register(
     'dot',
     'Graphviz',
     'http://www.graphviz.org/doc/info/lang.html',
-    array(
-        'text/vnd.graphviz' => 0.8
-    ),
-    array('gv', 'dot')
+    [
+        'text/vnd.graphviz' => 0.8,
+    ],
+    ['gv', 'dot']
 );
 
 Format::register(
@@ -640,72 +632,71 @@ Format::register(
     'n3',
     'Notation3',
     'http://www.w3.org/2000/10/swap/grammar/n3#',
-    array(
+    [
         'text/n3' => 0.5,
-        'text/rdf+n3' => 0.5
-    ),
-    array('n3')
+        'text/rdf+n3' => 0.5,
+    ],
+    ['n3']
 );
 
 Format::register(
     'rdfa',
     'RDFa',
     'http://www.w3.org/TR/rdfa-core/',
-    array(
+    [
         'text/html' => 0.4,
-        'application/xhtml+xml' => 0.4
-    ),
-    array('html')
+        'application/xhtml+xml' => 0.4,
+    ],
+    ['html']
 );
 
 Format::register(
     'sparql-xml',
     'SPARQL XML Query Results',
     'http://www.w3.org/TR/rdf-sparql-XMLres/',
-    array(
-        'application/sparql-results+xml' => 1.0
-    )
+    [
+        'application/sparql-results+xml' => 1.0,
+    ]
 );
 
 Format::register(
     'sparql-json',
     'SPARQL JSON Query Results',
     'http://www.w3.org/TR/rdf-sparql-json-res/',
-    array(
-        'application/sparql-results+json' => 1.0
-    )
+    [
+        'application/sparql-results+json' => 1.0,
+    ]
 );
 
 Format::register(
     'png',
     'Portable Network Graphics (PNG)',
     'http://www.w3.org/TR/PNG/',
-    array(
-        'image/png' => 0.3
-    ),
-    array('png')
+    [
+        'image/png' => 0.3,
+    ],
+    ['png']
 );
 
 Format::register(
     'gif',
     'Graphics Interchange Format (GIF)',
     'http://www.w3.org/Graphics/GIF/spec-gif89a.txt',
-    array(
-        'image/gif' => 0.2
-    ),
-    array('gif')
+    [
+        'image/gif' => 0.2,
+    ],
+    ['gif']
 );
 
 Format::register(
     'svg',
     'Scalable Vector Graphics (SVG)',
     'http://www.w3.org/TR/SVG/',
-    array(
-        'image/svg+xml' => 0.3
-    ),
-    array('svg')
+    [
+        'image/svg+xml' => 0.3,
+    ],
+    ['svg']
 );
-
 
 /*
    Register default set of parsers and serialisers

--- a/lib/Graph.php
+++ b/lib/Graph.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EasyRdf;
 
 /**
@@ -31,7 +32,6 @@ namespace EasyRdf;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
@@ -39,7 +39,6 @@ namespace EasyRdf;
 /**
  * Container for collection of EasyRdf\Resource objects.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
@@ -50,19 +49,18 @@ class Graph
     private $parsedUri = null;
 
     /** Array of resources contained in the graph */
-    private $resources = array();
+    private $resources = [];
 
-    private $index = array();
-    private $revIndex = array();
+    private $index = [];
+    private $revIndex = [];
 
     /** Counter for the number of bnodes */
     private $bNodeCount = 0;
 
     /** Array of URLs that have been loaded into the graph */
-    private $loaded = array();
+    private $loaded = [];
 
     private $maxRedirects = 10;
-
 
     /**
      * Constructor
@@ -75,9 +73,9 @@ class Graph
      * The data format is optional and should be specified if it
      * can't be guessed by EasyRdf.
      *
-     * @param  string  $uri     The URI of the graph
-     * @param  string  $data    Data for the graph
-     * @param  string  $format  The document type of the data (e.g. rdfxml)
+     * @param string $uri    The URI of the graph
+     * @param string $data   Data for the graph
+     * @param string $format The document type of the data (e.g. rdfxml)
      *
      * @return Graph
      */
@@ -104,15 +102,16 @@ class Graph
      * The document type is optional but should be specified if it
      * can't be guessed or got from the HTTP headers.
      *
-     * @param  string       $uri     The URI of the data to load
-     * @param  string|null  $format  Optional format of the data (eg. rdfxml)
+     * @param string      $uri    The URI of the data to load
+     * @param string|null $format Optional format of the data (eg. rdfxml)
      *
-     * @return Graph  The new the graph object
+     * @return Graph The new the graph object
      */
     public static function newAndLoad($uri, $format = null)
     {
         $graph = new self($uri);
         $graph->load($uri, $format);
+
         return $graph;
     }
 
@@ -125,19 +124,18 @@ class Graph
      *
      * If URI is null, then the URI of the graph is used.
      *
-     * @param  string  $uri    The URI of the resource
-     * @param  mixed   $types  RDF type of a new resource (e.g. foaf:Person)
+     * @param string $uri   The URI of the resource
+     * @param mixed  $types RDF type of a new resource (e.g. foaf:Person)
      *
      * @throws \InvalidArgumentException
+     *
      * @return \EasyRdf\Resource
      */
-    public function resource($uri = null, $types = array())
+    public function resource($uri = null, $types = [])
     {
         $this->checkResourceParam($uri, true);
         if (!$uri) {
-            throw new \InvalidArgumentException(
-                '$uri is null and EasyRdf\Graph object has no URI either.'
-            );
+            throw new \InvalidArgumentException('$uri is null and EasyRdf\Graph object has no URI either.');
         }
 
         // Resolve relative URIs
@@ -165,9 +163,9 @@ class Graph
         $rdfType = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
         if (isset($this->index[$uri][$rdfType])) {
             foreach ($this->index[$uri][$rdfType] as $type) {
-                if ($type['type'] == 'uri' or $type['type'] == 'bnode') {
+                if ('uri' == $type['type'] or 'bnode' == $type['type']) {
                     $class = TypeMapper::get($type['value']);
-                    if ($class != null) {
+                    if (null != $class) {
                         return $class;
                     }
                 }
@@ -176,12 +174,13 @@ class Graph
 
         // Parsers don't typically add a rdf:type to rdf:List, so we have to
         // do a bit of 'inference' here using properties.
-        if ($uri == 'http://www.w3.org/1999/02/22-rdf-syntax-ns#nil' or
+        if ('http://www.w3.org/1999/02/22-rdf-syntax-ns#nil' == $uri or
             isset($this->index[$uri]['http://www.w3.org/1999/02/22-rdf-syntax-ns#first']) or
             isset($this->index[$uri]['http://www.w3.org/1999/02/22-rdf-syntax-ns#rest'])
         ) {
             return 'EasyRdf\Collection';
         }
+
         return TypeMapper::getDefaultResourceClass();
     }
 
@@ -192,11 +191,11 @@ class Graph
      * with the EasyRdf\TypeMapper, then the resource will be an instance
      * of the class registered.
      *
-     * @param  mixed  $types  RDF type of a new blank node (e.g. foaf:Person)
+     * @param mixed $types RDF type of a new blank node (e.g. foaf:Person)
      *
      * @return \EasyRdf\Resource The new blank node
      */
-    public function newBNode($types = array())
+    public function newBNode($types = [])
     {
         return $this->resource($this->newBNodeId(), $types);
     }
@@ -208,24 +207,25 @@ class Graph
      */
     public function newBNodeId()
     {
-        return "_:genid".(++$this->bNodeCount);
+        return '_:genid'.(++$this->bNodeCount);
     }
 
     /**
      * Parse some RDF data into the graph object.
      *
-     * @param  string  $data    Data to parse for the graph
-     * @param  string  $format  Optional format of the data
-     * @param  string  $uri     The URI of the data to load
+     * @param string $data   Data to parse for the graph
+     * @param string $format Optional format of the data
+     * @param string $uri    The URI of the data to load
      *
      * @throws Exception
-     * @return integer          The number of triples added to the graph
+     *
+     * @return int The number of triples added to the graph
      */
     public function parse($data, $format = null, $uri = null)
     {
         $this->checkResourceParam($uri, true);
 
-        if (empty($format) or $format == 'guess') {
+        if (empty($format) or 'guess' == $format) {
             // Guess the format if it is Unknown
             $format = Format::guessFormat($data, $uri);
         } else {
@@ -233,27 +233,26 @@ class Graph
         }
 
         if (!$format) {
-            throw new Exception(
-                "Unable to parse data of an unknown format."
-            );
+            throw new Exception('Unable to parse data of an unknown format.');
         }
 
         $parser = $format->newParser();
+
         return $parser->parse($this, $data, $format, $uri);
     }
 
     /**
      * Parse a file containing RDF data into the graph object.
      *
-     * @param  string  $filename The path of the file to load
-     * @param  string  $format   Optional format of the file
-     * @param  string  $uri      The URI of the file to load
+     * @param string $filename The path of the file to load
+     * @param string $format   Optional format of the file
+     * @param string $uri      The URI of the file to load
      *
-     * @return integer           The number of triples added to the graph
+     * @return int The number of triples added to the graph
      */
     public function parseFile($filename, $format = null, $uri = null)
     {
-        if ($uri === null) {
+        if (null === $uri) {
             $uri = "file://$filename";
         }
 
@@ -272,27 +271,26 @@ class Graph
      * The document type is optional but should be specified if it
      * can't be guessed or got from the HTTP headers.
      *
-     * @param  string  $uri     The URI of the data to load
-     * @param  string  $format  Optional format of the data (eg. rdfxml)
+     * @param string $uri    The URI of the data to load
+     * @param string $format Optional format of the data (eg. rdfxml)
      *
      * @throws Exception
      * @throws Http\Exception
-     * @return integer          The number of triples added to the graph
+     *
+     * @return int The number of triples added to the graph
      */
     public function load($uri = null, $format = null)
     {
         $this->checkResourceParam($uri, true);
 
         if (!$uri) {
-            throw new Exception(
-                "No URI given to load() and the graph does not have a URI."
-            );
+            throw new Exception('No URI given to load() and the graph does not have a URI.');
         }
 
         // Setup the HTTP client
         $client = Http::getDefaultHttpClient();
         $client->resetParameters(true);
-        $client->setConfig(array('maxredirects' => 0));
+        $client->setConfig(['maxredirects' => 0]);
         $client->setMethod('GET');
         $client->setHeaders('Accept', Format::getHttpAcceptHeader());
 
@@ -302,7 +300,7 @@ class Graph
         do {
             // Have we already loaded it into the graph?
             $requestUrl = Utils::removeFragmentFromUri($requestUrl);
-            if (in_array($requestUrl, $this->loaded)) {
+            if (\in_array($requestUrl, $this->loaded)) {
                 return 0;
             }
 
@@ -325,7 +323,7 @@ class Graph
                 $requestUrl = Utils::removeFragmentFromUri($requestUrl);
 
                 // If it is a 303 then drop the parameters
-                if ($response->getStatus() == 303) {
+                if (303 == $response->getStatus()) {
                     $client->resetParameters();
                 }
 
@@ -334,17 +332,12 @@ class Graph
                 // If we didn't get any location, stop redirecting
                 break;
             } else {
-                throw new Http\Exception(
-                    "HTTP request for {$requestUrl} failed: ".$response->getMessage(),
-                    $response->getStatus(),
-                    null,
-                    $response->getBody()
-                );
+                throw new Http\Exception("HTTP request for {$requestUrl} failed: ".$response->getMessage(), $response->getStatus(), null, $response->getBody());
             }
         } while ($redirectCounter < $this->maxRedirects);
 
-        if (!$format or $format == 'guess') {
-            list($format, ) = Utils::parseMimeType(
+        if (!$format or 'guess' == $format) {
+            list($format) = Utils::parseMimeType(
                 $response->getHeader('Content-Type')
             );
         }
@@ -356,7 +349,7 @@ class Graph
     /** Get an associative array of all the resources stored in the graph.
      *  The keys of the array is the URI of the EasyRdf\Resource.
      *
-     * @return Resource[]
+     * @return resource[]
      */
     public function resources()
     {
@@ -387,10 +380,10 @@ class Graph
      * Or all homepages:
      * $people = $graph->resourcesMatching('^foaf:homepage');
      *
-     * @param  string  $property   The property to check.
-     * @param  mixed   $value      Optional, the value of the propery to check for.
+     * @param string $property the property to check
+     * @param mixed  $value    optional, the value of the propery to check for
      *
-     * @return Resource[]
+     * @return resource[]
      */
     public function resourcesMatching($property, $value = null)
     {
@@ -404,7 +397,7 @@ class Graph
             $index = &$this->index;
         }
 
-        $matched = array();
+        $matched = [];
         foreach ($index as $subject => $props) {
             if (isset($index[$subject][$property])) {
                 if (isset($value)) {
@@ -420,6 +413,7 @@ class Graph
                 }
             }
         }
+
         return $matched;
     }
 
@@ -437,73 +431,62 @@ class Graph
      */
     protected function checkResourceParam(&$resource, $allowNull = false)
     {
-        if ($allowNull == true) {
-            if ($resource === null) {
+        if (true == $allowNull) {
+            if (null === $resource) {
                 if ($this->uri) {
                     $resource = $this->uri;
                 } else {
                     return;
                 }
             }
-        } elseif ($resource === null) {
-            throw new \InvalidArgumentException(
-                '$resource should be either IRI, blank-node identifier or EasyRdf\Resource. got null'
-            );
+        } elseif (null === $resource) {
+            throw new \InvalidArgumentException('$resource should be either IRI, blank-node identifier or EasyRdf\Resource. got null');
         }
 
-        if (is_object($resource) and $resource instanceof Resource) {
+        if (\is_object($resource) and $resource instanceof Resource) {
             $resource = $resource->getUri();
-        } elseif (is_object($resource) and $resource instanceof ParsedUri) {
-            $resource = strval($resource);
-        } elseif (is_string($resource)) {
-            if ($resource == '') {
-                throw new \InvalidArgumentException(
-                    '$resource should be either IRI, blank-node identifier or EasyRdf\Resource. got empty string'
-                );
-            } elseif (preg_match("|^<(.+)>$|", $resource, $matches)) {
+        } elseif (\is_object($resource) and $resource instanceof ParsedUri) {
+            $resource = (string) $resource;
+        } elseif (\is_string($resource)) {
+            if ('' == $resource) {
+                throw new \InvalidArgumentException('$resource should be either IRI, blank-node identifier or EasyRdf\Resource. got empty string');
+            } elseif (preg_match('|^<(.+)>$|', $resource, $matches)) {
                 $resource = $matches[1];
             } else {
                 $resource = RdfNamespace::expand($resource);
             }
         } else {
-            throw new \InvalidArgumentException(
-                '$resource should be either IRI, blank-node identifier or EasyRdf\Resource'
-            );
+            throw new \InvalidArgumentException('$resource should be either IRI, blank-node identifier or EasyRdf\Resource');
         }
     }
 
     /** Check that a single URI/property parameter (not a property path)
      *  is valid, and expand it if required
+     *
      *  @ignore
      */
     protected function checkSinglePropertyParam(&$property, &$inverse)
     {
-        if (is_object($property) and $property instanceof Resource) {
+        if (\is_object($property) and $property instanceof Resource) {
             $property = $property->getUri();
-        } elseif (is_object($property) and $property instanceof ParsedUri) {
-            $property = strval($property);
-        } elseif (is_string($property)) {
-            if ($property == '') {
-                throw new \InvalidArgumentException(
-                    "\$property cannot be an empty string"
-                );
-            } elseif (substr($property, 0, 1) == '^') {
+        } elseif (\is_object($property) and $property instanceof ParsedUri) {
+            $property = (string) $property;
+        } elseif (\is_string($property)) {
+            if ('' == $property) {
+                throw new \InvalidArgumentException('$property cannot be an empty string');
+            } elseif ('^' == substr($property, 0, 1)) {
                 $inverse = true;
                 $property = RdfNamespace::expand(substr($property, 1));
-            } elseif (substr($property, 0, 2) == '_:') {
-                throw new \InvalidArgumentException(
-                    "\$property cannot be a blank node"
-                );
+            } elseif ('_:' == substr($property, 0, 2)) {
+                throw new \InvalidArgumentException('$property cannot be a blank node');
             } else {
                 $inverse = false;
                 $property = RdfNamespace::expand($property);
             }
         }
 
-        if ($property === null or !is_string($property)) {
-            throw new \InvalidArgumentException(
-                '$property should be a string or EasyRdf\Resource and cannot be null'
-            );
+        if (null === $property or !\is_string($property)) {
+            throw new \InvalidArgumentException('$property should be a string or EasyRdf\Resource and cannot be null');
         }
     }
 
@@ -513,43 +496,37 @@ class Graph
     protected function checkValueParam(&$value)
     {
         if (isset($value)) {
-            if (is_object($value)) {
+            if (\is_object($value)) {
                 if (!method_exists($value, 'toRdfPhp')) {
                     // Convert to a literal object
                     $value = Literal::create($value);
                 }
                 $value = $value->toRdfPhp();
-            } elseif (is_array($value)) {
+            } elseif (\is_array($value)) {
                 if (!isset($value['type'])) {
-                    throw new \InvalidArgumentException(
-                        "\$value is missing a 'type' key"
-                    );
+                    throw new \InvalidArgumentException("\$value is missing a 'type' key");
                 }
 
                 if (!isset($value['value'])) {
-                    throw new \InvalidArgumentException(
-                        "\$value is missing a 'value' key"
-                    );
+                    throw new \InvalidArgumentException("\$value is missing a 'value' key");
                 }
 
                 // Fix ordering and remove unknown keys
-                $value = array(
-                    'type' => strval($value['type']),
-                    'value' => strval($value['value']),
-                    'lang' => isset($value['lang']) ? strval($value['lang']) : null,
-                    'datatype' => isset($value['datatype']) ? strval($value['datatype']) : null
-                );
+                $value = [
+                    'type' => (string) ($value['type']),
+                    'value' => (string) ($value['value']),
+                    'lang' => isset($value['lang']) ? (string) ($value['lang']) : null,
+                    'datatype' => isset($value['datatype']) ? (string) ($value['datatype']) : null,
+                ];
             } else {
-                $value = array(
+                $value = [
                     'type' => 'literal',
-                    'value' => strval($value),
-                    'datatype' => Literal::getDatatypeForValue($value)
-                );
+                    'value' => (string) $value,
+                    'datatype' => Literal::getDatatypeForValue($value),
+                ];
             }
-            if (!in_array($value['type'], array('uri', 'bnode', 'literal'), true)) {
-                throw new \InvalidArgumentException(
-                    "\$value does not have a valid type (".$value['type'].")"
-                );
+            if (!\in_array($value['type'], ['uri', 'bnode', 'literal'], true)) {
+                throw new \InvalidArgumentException('$value does not have a valid type ('.$value['type'].')');
             }
             if (empty($value['datatype'])) {
                 unset($value['datatype']);
@@ -558,9 +535,7 @@ class Graph
                 unset($value['lang']);
             }
             if (isset($value['lang']) and isset($value['datatype'])) {
-                throw new \InvalidArgumentException(
-                    "\$value cannot have both and language and a datatype"
-                );
+                throw new \InvalidArgumentException('$value cannot have both and language and a datatype');
             }
         }
     }
@@ -575,30 +550,27 @@ class Graph
      *
      * This method will return null if the property does not exist.
      *
-     * @param  string    $resource       The URI of the resource (e.g. http://example.com/joe#me)
-     * @param  string    $propertyPath   A valid property path
-     * @param  string    $type           The type of value to filter by (e.g. literal or resource)
-     * @param  string    $lang           The language to filter by (e.g. en)
+     * @param string $resource     The URI of the resource (e.g. http://example.com/joe#me)
+     * @param string $propertyPath A valid property path
+     * @param string $type         The type of value to filter by (e.g. literal or resource)
+     * @param string $lang         The language to filter by (e.g. en)
      *
      * @throws \InvalidArgumentException
-     * @return mixed                     A value associated with the property
+     *
+     * @return mixed A value associated with the property
      */
     public function get($resource, $propertyPath, $type = null, $lang = null)
     {
         $this->checkResourceParam($resource);
 
-        if (is_object($propertyPath) and $propertyPath instanceof Resource) {
+        if (\is_object($propertyPath) and $propertyPath instanceof Resource) {
             return $this->getSingleProperty($resource, $propertyPath->getUri(), $type, $lang);
-        } elseif (is_string($propertyPath) and preg_match('|^(\^?)<(.+)>|', $propertyPath, $matches)) {
+        } elseif (\is_string($propertyPath) and preg_match('|^(\^?)<(.+)>|', $propertyPath, $matches)) {
             return $this->getSingleProperty($resource, "$matches[1]$matches[2]", $type, $lang);
-        } elseif ($propertyPath === null or !is_string($propertyPath)) {
-            throw new \InvalidArgumentException(
-                '$propertyPath should be a string or EasyRdf\Resource and cannot be null'
-            );
-        } elseif ($propertyPath === '') {
-            throw new \InvalidArgumentException(
-                "\$propertyPath cannot be an empty string"
-            );
+        } elseif (null === $propertyPath or !\is_string($propertyPath)) {
+            throw new \InvalidArgumentException('$propertyPath should be a string or EasyRdf\Resource and cannot be null');
+        } elseif ('' === $propertyPath) {
+            throw new \InvalidArgumentException('$propertyPath cannot be an empty string');
         }
 
         $originalResource = $resource;
@@ -625,7 +597,7 @@ class Graph
         }
 
         // Try an exact path if nothing else works
-        if (is_null($resource)) {
+        if (null === $resource) {
             $resource = $this->getSingleProperty($originalResource, $propertyPath, $type, $lang);
         }
 
@@ -634,12 +606,12 @@ class Graph
 
     /** Get a single value for a property of a resource
      *
-     * @param  string    $resource The URI of the resource (e.g. http://example.com/joe#me)
-     * @param  string    $property The name of the property (e.g. foaf:name)
-     * @param  string    $type     The type of value to filter by (e.g. literal or resource)
-     * @param  string    $lang     The language to filter by (e.g. en)
+     * @param string $resource The URI of the resource (e.g. http://example.com/joe#me)
+     * @param string $property The name of the property (e.g. foaf:name)
+     * @param string $type     The type of value to filter by (e.g. literal or resource)
+     * @param string $lang     The language to filter by (e.g. en)
      *
-     * @return mixed               A value associated with the property
+     * @return mixed A value associated with the property
      *
      * @ignore
      */
@@ -658,13 +630,13 @@ class Graph
         $result = null;
         if ($type) {
             foreach ($values as $value) {
-                if ($type == 'literal' and $value['type'] == 'literal') {
-                    if ($lang == null or (isset($value['lang']) and $value['lang'] == $lang)) {
+                if ('literal' == $type and 'literal' == $value['type']) {
+                    if (null == $lang or (isset($value['lang']) and $value['lang'] == $lang)) {
                         $result = $value;
                         break;
                     }
-                } elseif ($type == 'resource') {
-                    if ($value['type'] == 'uri' or $value['type'] == 'bnode') {
+                } elseif ('resource' == $type) {
+                    if ('uri' == $value['type'] or 'bnode' == $value['type']) {
                         $result = $value;
                         break;
                     }
@@ -686,11 +658,11 @@ class Graph
      * This method will return null if there is not literal value for the
      * property.
      *
-     * @param  string       $resource The URI of the resource (e.g. http://example.com/joe#me)
-     * @param  string|array $property The name of the property (e.g. foaf:name)
-     * @param  string       $lang     The language to filter by (e.g. en)
+     * @param string       $resource The URI of the resource (e.g. http://example.com/joe#me)
+     * @param string|array $property The name of the property (e.g. foaf:name)
+     * @param string       $lang     The language to filter by (e.g. en)
      *
-     * @return Literal  Literal value associated with the property
+     * @return Literal Literal value associated with the property
      */
     public function getLiteral($resource, $property, $lang = null)
     {
@@ -705,10 +677,10 @@ class Graph
      * This method will return null if there is not resource for the
      * property.
      *
-     * @param  string       $resource The URI of the resource (e.g. http://example.com/joe#me)
-     * @param  string|array $property The name of the property (e.g. foaf:name)
+     * @param string       $resource The URI of the resource (e.g. http://example.com/joe#me)
+     * @param string|array $property The name of the property (e.g. foaf:name)
      *
-     * @return \EasyRdf\Resource  Resource associated with the property
+     * @return \EasyRdf\Resource Resource associated with the property
      */
     public function getResource($resource, $property)
     {
@@ -744,7 +716,7 @@ class Graph
     protected function arrayToObject($data)
     {
         if ($data) {
-            if ($data['type'] == 'uri' or $data['type'] == 'bnode') {
+            if ('uri' == $data['type'] or 'bnode' == $data['type']) {
                 return $this->resource($data['value']);
             } else {
                 return Literal::create($data);
@@ -758,38 +730,34 @@ class Graph
      *
      * This method will return an empty array if the property does not exist.
      *
-     * @param  string  $resource      The URI of the resource (e.g. http://example.com/joe#me)
-     * @param  string  $propertyPath  A valid property path
-     * @param  string  $type          The type of value to filter by (e.g. literal)
-     * @param  string  $lang          The language to filter by (e.g. en)
+     * @param string $resource     The URI of the resource (e.g. http://example.com/joe#me)
+     * @param string $propertyPath A valid property path
+     * @param string $type         The type of value to filter by (e.g. literal)
+     * @param string $lang         The language to filter by (e.g. en)
      *
      * @throws \InvalidArgumentException
-     * @return array                  An array of values associated with the property
+     *
+     * @return array An array of values associated with the property
      */
     public function all($resource, $propertyPath, $type = null, $lang = null)
     {
         $this->checkResourceParam($resource);
 
-        if (is_object($propertyPath) and $propertyPath instanceof Resource) {
+        if (\is_object($propertyPath) and $propertyPath instanceof Resource) {
             return $this->allForSingleProperty($resource, $propertyPath->getUri(), $type, $lang);
-        } elseif (is_string($propertyPath) and preg_match('|^(\^?)<(.+)>|', $propertyPath, $matches)) {
+        } elseif (\is_string($propertyPath) and preg_match('|^(\^?)<(.+)>|', $propertyPath, $matches)) {
             return $this->allForSingleProperty($resource, "$matches[1]$matches[2]", $type, $lang);
-        } elseif ($propertyPath === null or !is_string($propertyPath)) {
-            throw new \InvalidArgumentException(
-                '$propertyPath should be a string or EasyRdf\Resource and cannot be null'
-            );
-        } elseif ($propertyPath === '') {
-            throw new \InvalidArgumentException(
-                "\$propertyPath cannot be an empty string"
-            );
+        } elseif (null === $propertyPath or !\is_string($propertyPath)) {
+            throw new \InvalidArgumentException('$propertyPath should be a string or EasyRdf\Resource and cannot be null');
+        } elseif ('' === $propertyPath) {
+            throw new \InvalidArgumentException('$propertyPath cannot be an empty string');
         }
 
-        $objects = array($resource);
+        $objects = [$resource];
 
         // Loop through each component in the path
         foreach (explode('/', $propertyPath) as $part) {
-
-            $results = array();
+            $results = [];
             foreach (explode('|', $part) as $p) {
                 foreach ($objects as $o) {
                     // Ignore literals found earlier in path
@@ -818,12 +786,12 @@ class Graph
 
     /** Get all values for a single property of a resource
      *
-     * @param  string  $resource The URI of the resource (e.g. http://example.com/joe#me)
-     * @param  string  $property The name of the property (e.g. foaf:name)
-     * @param  string  $type     The type of value to filter by (e.g. literal)
-     * @param  string  $lang     The language to filter by (e.g. en)
+     * @param string $resource The URI of the resource (e.g. http://example.com/joe#me)
+     * @param string $property The name of the property (e.g. foaf:name)
+     * @param string $type     The type of value to filter by (e.g. literal)
+     * @param string $lang     The language to filter by (e.g. en)
      *
-     * @return array             An array of values associated with the property
+     * @return array An array of values associated with the property
      *
      * @ignore
      */
@@ -835,18 +803,18 @@ class Graph
         // Get an array of values for the property
         $values = $this->propertyValuesArray($resource, $property, $inverse);
         if (!isset($values)) {
-            return array();
+            return [];
         }
 
-        $objects = array();
+        $objects = [];
         if ($type) {
             foreach ($values as $value) {
-                if ($type == 'literal' and $value['type'] == 'literal') {
-                    if ($lang == null or (isset($value['lang']) and $value['lang'] == $lang)) {
+                if ('literal' == $type and 'literal' == $value['type']) {
+                    if (null == $lang or (isset($value['lang']) and $value['lang'] == $lang)) {
                         $objects[] = $this->arrayToObject($value);
                     }
-                } elseif ($type == 'resource') {
-                    if ($value['type'] == 'uri' or $value['type'] == 'bnode') {
+                } elseif ('resource' == $type) {
+                    if ('uri' == $value['type'] or 'bnode' == $value['type']) {
                         $objects[] = $this->arrayToObject($value);
                     }
                 }
@@ -856,6 +824,7 @@ class Graph
                 $objects[] = $this->arrayToObject($value);
             }
         }
+
         return $objects;
     }
 
@@ -864,11 +833,11 @@ class Graph
      * This method will return an empty array if the resource does not
      * has any literal values for that property.
      *
-     * @param  string  $resource The URI of the resource (e.g. http://example.com/joe#me)
-     * @param  string  $property The name of the property (e.g. foaf:name)
-     * @param  string  $lang     The language to filter by (e.g. en)
+     * @param string $resource The URI of the resource (e.g. http://example.com/joe#me)
+     * @param string $property The name of the property (e.g. foaf:name)
+     * @param string $lang     The language to filter by (e.g. en)
      *
-     * @return array             An array of values associated with the property
+     * @return array An array of values associated with the property
      */
     public function allLiterals($resource, $property, $lang = null)
     {
@@ -880,10 +849,10 @@ class Graph
      * This method will return an empty array if the resource does not
      * has any resources for that property.
      *
-     * @param  string  $resource The URI of the resource (e.g. http://example.com/joe#me)
-     * @param  string  $property The name of the property (e.g. foaf:name)
+     * @param string $resource The URI of the resource (e.g. http://example.com/joe#me)
+     * @param string $property The name of the property (e.g. foaf:name)
      *
-     * @return array             An array of values associated with the property
+     * @return array An array of values associated with the property
      */
     public function allResources($resource, $property)
     {
@@ -895,7 +864,7 @@ class Graph
      * If no resources of the type are available and empty
      * array is returned.
      *
-     * @param  string  $type   The type of the resource (e.g. foaf:Person)
+     * @param string $type The type of the resource (e.g. foaf:Person)
      *
      * @return array The array of resources
      */
@@ -906,16 +875,16 @@ class Graph
 
     /** Count the number of values for a property of a resource
      *
-     * @param  string  $resource The URI of the resource (e.g. http://example.com/joe#me)
-     * @param  string  $property The name of the property (e.g. foaf:name)
-     * @param  string  $type     The type of value to filter by (e.g. literal)
-     * @param  string  $lang     The language to filter by (e.g. en)
+     * @param string $resource The URI of the resource (e.g. http://example.com/joe#me)
+     * @param string $property The name of the property (e.g. foaf:name)
+     * @param string $type     The type of value to filter by (e.g. literal)
+     * @param string $lang     The language to filter by (e.g. en)
      *
-     * @return integer           The number of values for this property
+     * @return int The number of values for this property
      */
     public function countValues($resource, $property, $type = null, $lang = null)
     {
-        return count($this->all($resource, $property, $type, $lang));
+        return \count($this->all($resource, $property, $type, $lang));
     }
 
     /** Concatenate all values for a property of a resource into a string.
@@ -923,16 +892,16 @@ class Graph
      * The default is to join the values together with a space character.
      * This method will return an empty string if the property does not exist.
      *
-     * @param  mixed   $resource The resource to get the property on
-     * @param  string  $property The name of the property (e.g. foaf:name)
-     * @param  string  $glue     The string to glue the values together with.
-     * @param  string  $lang     The language to filter by (e.g. en)
+     * @param mixed  $resource The resource to get the property on
+     * @param string $property The name of the property (e.g. foaf:name)
+     * @param string $glue     the string to glue the values together with
+     * @param string $lang     The language to filter by (e.g. en)
      *
-     * @return string            Concatenation of all the values.
+     * @return string concatenation of all the values
      */
     public function join($resource, $property, $glue = ' ', $lang = null)
     {
-        return join($glue, $this->all($resource, $property, 'literal', $lang));
+        return implode($glue, $this->all($resource, $property, 'literal', $lang));
     }
 
     /** Add data to the graph
@@ -942,11 +911,11 @@ class Graph
      * Example:
      *   $graph->add("http://www.example.com", 'dc:title', 'Title of Page');
      *
-     * @param  mixed $resource   The resource to add data to
-     * @param  mixed $property   The property name
-     * @param  mixed $value      The new value for the property
+     * @param mixed $resource The resource to add data to
+     * @param mixed $property The property name
+     * @param mixed $value    The new value for the property
      *
-     * @return integer           The number of values added (1 or 0)
+     * @return int The number of values added (1 or 0)
      */
     public function add($resource, $property, $value)
     {
@@ -955,7 +924,7 @@ class Graph
         $this->checkValueParam($value);
 
         // No value given?
-        if ($value === null) {
+        if (null === $value) {
             return 0;
         }
 
@@ -970,12 +939,12 @@ class Graph
         $this->index[$resource][$property][] = $value;
 
         // Add to the reverse index if it is a resource
-        if ($value['type'] == 'uri' or $value['type'] == 'bnode') {
+        if ('uri' == $value['type'] or 'bnode' == $value['type']) {
             $uri = $value['value'];
-            $this->revIndex[$uri][$property][] = array(
-                'type' => substr($resource, 0, 2) == '_:' ? 'bnode' : 'uri',
-                'value' => $resource
-            );
+            $this->revIndex[$uri][$property][] = [
+                'type' => '_:' == substr($resource, 0, 2) ? 'bnode' : 'uri',
+                'value' => $resource,
+            ];
         }
 
         // Success
@@ -990,27 +959,29 @@ class Graph
      * Example:
      *   $graph->add("http://www.example.com", 'dc:title', 'Title of Page');
      *
-     * @param  mixed  $resource  The resource to add data to
-     * @param  mixed  $property  The property name
-     * @param  mixed  $value     The value or values for the property
-     * @param  string $lang      The language of the literal
+     * @param mixed  $resource The resource to add data to
+     * @param mixed  $property The property name
+     * @param mixed  $value    The value or values for the property
+     * @param string $lang     The language of the literal
      *
-     * @return integer           The number of values added
+     * @return int The number of values added
      */
     public function addLiteral($resource, $property, $value, $lang = null)
     {
         $this->checkResourceParam($resource);
         $this->checkSinglePropertyParam($property, $inverse);
 
-        if (is_array($value)) {
+        if (\is_array($value)) {
             $added = 0;
             foreach ($value as $v) {
                 $added += $this->addLiteral($resource, $property, $v, $lang);
             }
+
             return $added;
-        } elseif (!is_object($value) or !$value instanceof Literal) {
+        } elseif (!\is_object($value) or !$value instanceof Literal) {
             $value = Literal::create($value, $lang);
         }
+
         return $this->add($resource, $property, $value);
     }
 
@@ -1021,11 +992,11 @@ class Graph
      * Example:
      *   $graph->add("http://example.com/bob", 'foaf:knows', 'http://example.com/alice');
      *
-     * @param  mixed $resource   The resource to add data to
-     * @param  mixed $property   The property name
-     * @param  mixed $resource2  The resource to be value of the property
+     * @param mixed $resource  The resource to add data to
+     * @param mixed $property  The property name
+     * @param mixed $resource2 The resource to be value of the property
      *
-     * @return integer           The number of values added
+     * @return int The number of values added
      */
     public function addResource($resource, $property, $resource2)
     {
@@ -1036,10 +1007,10 @@ class Graph
         return $this->add(
             $resource,
             $property,
-            array(
-                'type' => substr($resource2, 0, 2) == '_:' ? 'bnode' : 'uri',
-                'value' => $resource2
-            )
+            [
+                'type' => '_:' == substr($resource2, 0, 2) ? 'bnode' : 'uri',
+                'value' => $resource2,
+            ]
         );
     }
 
@@ -1047,11 +1018,11 @@ class Graph
      *
      * The new value will replace the existing values for the property.
      *
-     * @param  string  $resource The resource to set the property on
-     * @param  string  $property The name of the property (e.g. foaf:name)
-     * @param  mixed   $value    The value for the property
+     * @param string $resource The resource to set the property on
+     * @param string $property The name of the property (e.g. foaf:name)
+     * @param mixed  $value    The value for the property
      *
-     * @return integer           The number of values added (1 or 0)
+     * @return int The number of values added (1 or 0)
      */
     public function set($resource, $property, $value)
     {
@@ -1068,43 +1039,39 @@ class Graph
 
     /** Delete a property (or optionally just a specific value)
      *
-     * @param  mixed   $resource The resource to delete the property from
-     * @param  string  $property The name of the property (e.g. foaf:name)
-     * @param  mixed   $value The value to delete (null to delete all values)
+     * @param mixed  $resource The resource to delete the property from
+     * @param string $property The name of the property (e.g. foaf:name)
+     * @param mixed  $value    The value to delete (null to delete all values)
      *
      * @throws \InvalidArgumentException
-     * @return integer The number of values deleted
+     *
+     * @return int The number of values deleted
      */
     public function delete($resource, $property, $value = null)
     {
         $this->checkResourceParam($resource);
 
-        if (is_object($property) and $property instanceof Resource) {
+        if (\is_object($property) and $property instanceof Resource) {
             return $this->deleteSingleProperty($resource, $property->getUri(), $value);
-        } elseif (is_string($property) and preg_match('|^(\^?)<(.+)>|', $property, $matches)) {
+        } elseif (\is_string($property) and preg_match('|^(\^?)<(.+)>|', $property, $matches)) {
             return $this->deleteSingleProperty($resource, "$matches[1]$matches[2]", $value);
-        } elseif ($property === null or !is_string($property)) {
-            throw new \InvalidArgumentException(
-                '$property should be a string or EasyRdf\Resource and cannot be null'
-            );
-        } elseif ($property === '') {
-            throw new \InvalidArgumentException(
-                "\$property cannot be an empty string"
-            );
+        } elseif (null === $property or !\is_string($property)) {
+            throw new \InvalidArgumentException('$property should be a string or EasyRdf\Resource and cannot be null');
+        } elseif ('' === $property) {
+            throw new \InvalidArgumentException('$property cannot be an empty string');
         }
 
         // FIXME: finish implementing property paths for delete
         return $this->deleteSingleProperty($resource, $property, $value);
     }
 
-
     /** Delete a property (or optionally just a specific value)
      *
-     * @param  mixed   $resource The resource to delete the property from
-     * @param  string  $property The name of the property (e.g. foaf:name)
-     * @param  mixed   $value The value to delete (null to delete all values)
+     * @param mixed  $resource The resource to delete the property from
+     * @param string $property The name of the property (e.g. foaf:name)
+     * @param mixed  $value    The value to delete (null to delete all values)
      *
-     * @return integer The number of values deleted
+     * @return int The number of values deleted
      *
      * @ignore
      */
@@ -1116,11 +1083,11 @@ class Graph
 
         $count = 0;
         if (isset($this->index[$resource][$property])) {
-            $newValues = array();
+            $newValues = [];
             foreach ($this->index[$resource][$property] as $k => $v) {
                 if (!$value or $v == $value) {
-                    $count++;
-                    if ($v['type'] == 'uri' or $v['type'] == 'bnode') {
+                    ++$count;
+                    if ('uri' == $v['type'] or 'bnode' == $v['type']) {
                         $this->deleteInverse($v['value'], $property, $resource);
                     }
                 } else {
@@ -1130,12 +1097,12 @@ class Graph
 
             // Clean up the indexes - remove empty properties and resources
             if ($count) {
-                if (count($newValues) == 0) {
+                if (0 == \count($newValues)) {
                     unset($this->index[$resource][$property]);
                 } else {
                     $this->index[$resource][$property] = $newValues;
                 }
-                if (count($this->index[$resource]) == 0) {
+                if (0 == \count($this->index[$resource])) {
                     unset($this->index[$resource]);
                 }
             }
@@ -1151,11 +1118,11 @@ class Graph
      * Example:
      *   $graph->delete("http://example.com/bob", 'foaf:knows', 'http://example.com/alice');
      *
-     * @param  mixed $resource   The resource to delete data from
-     * @param  mixed $property   The property name
-     * @param  mixed $resource2  The resource value of the property to be deleted
+     * @param mixed $resource  The resource to delete data from
+     * @param mixed $property  The property name
+     * @param mixed $resource2 The resource value of the property to be deleted
      *
-     * @return integer
+     * @return int
      */
     public function deleteResource($resource, $property, $resource2)
     {
@@ -1166,10 +1133,10 @@ class Graph
         return $this->delete(
             $resource,
             $property,
-            array(
-                'type' => substr($resource2, 0, 2) == '_:' ? 'bnode' : 'uri',
-                'value' => $resource2
-            )
+            [
+                'type' => '_:' == substr($resource2, 0, 2) ? 'bnode' : 'uri',
+                'value' => $resource2,
+            ]
         );
     }
 
@@ -1178,12 +1145,12 @@ class Graph
      * Example:
      *   $graph->delete("http://www.example.com", 'dc:title', 'Title of Page');
      *
-     * @param  mixed  $resource  The resource to add data to
-     * @param  mixed  $property  The property name
-     * @param  mixed  $value     The value of the property
-     * @param  string $lang      The language of the literal
+     * @param mixed  $resource The resource to add data to
+     * @param mixed  $property The property name
+     * @param mixed  $value    The value of the property
+     * @param string $lang     The language of the literal
      *
-     * @return integer
+     * @return int
      */
     public function deleteLiteral($resource, $property, $value, $lang = null)
     {
@@ -1212,10 +1179,10 @@ class Graph
                     unset($this->revIndex[$resource][$property][$k]);
                 }
             }
-            if (count($this->revIndex[$resource][$property]) == 0) {
+            if (0 == \count($this->revIndex[$resource][$property])) {
                 unset($this->revIndex[$resource][$property]);
             }
-            if (count($this->revIndex[$resource]) == 0) {
+            if (0 == \count($this->revIndex[$resource])) {
                 unset($this->revIndex[$resource]);
             }
         }
@@ -1223,11 +1190,11 @@ class Graph
 
     /** Check if the graph contains any statements
      *
-     * @return boolean True if the graph contains no statements
+     * @return bool True if the graph contains no statements
      */
     public function isEmpty()
     {
-        return count($this->index) == 0;
+        return 0 == \count($this->index);
     }
 
     /** Get a list of all the shortened property names (qnames) for a resource.
@@ -1236,13 +1203,13 @@ class Graph
      *
      * @param string $resource
      *
-     * @return array            Array of shortened URIs
+     * @return array Array of shortened URIs
      */
     public function properties($resource)
     {
         $this->checkResourceParam($resource);
 
-        $properties = array();
+        $properties = [];
         if (isset($this->index[$resource])) {
             foreach ($this->index[$resource] as $property => $value) {
                 $short = RdfNamespace::shorten($property);
@@ -1251,6 +1218,7 @@ class Graph
                 }
             }
         }
+
         return $properties;
     }
 
@@ -1260,7 +1228,7 @@ class Graph
      *
      * @param string $resource
      *
-     * @return array            Array of full URIs
+     * @return array Array of full URIs
      */
     public function propertyUris($resource)
     {
@@ -1269,7 +1237,7 @@ class Graph
         if (isset($this->index[$resource])) {
             return array_keys($this->index[$resource]);
         } else {
-            return array();
+            return [];
         }
     }
 
@@ -1277,7 +1245,7 @@ class Graph
      *
      * @param string $resource
      *
-     * @return array   Array of full property URIs
+     * @return array Array of full property URIs
      */
     public function reversePropertyUris($resource)
     {
@@ -1286,7 +1254,7 @@ class Graph
         if (isset($this->revIndex[$resource])) {
             return array_keys($this->revIndex[$resource]);
         } else {
-            return array();
+            return [];
         }
     }
 
@@ -1299,11 +1267,11 @@ class Graph
      * By providing a value parameter you can use this function to check
      * to see if a triple exists in the graph.
      *
-     * @param  mixed   $resource The resource to check
-     * @param  string  $property The name of the property (e.g. foaf:name)
-     * @param  mixed   $value    An optional value of the property
+     * @param mixed  $resource The resource to check
+     * @param string $property The name of the property (e.g. foaf:name)
+     * @param mixed  $value    An optional value of the property
      *
-     * @return boolean           True if value the property exists.
+     * @return bool true if value the property exists
      */
     public function hasProperty($resource, $property, $value = null)
     {
@@ -1319,7 +1287,7 @@ class Graph
         }
 
         if (isset($index[$resource][$property])) {
-            if (is_null($value)) {
+            if (null === $value) {
                 return true;
             } else {
                 foreach ($index[$resource][$property] as $v) {
@@ -1341,17 +1309,18 @@ class Graph
      * Example:
      *   $turtle = $graph->serialise('turtle');
      *
-     * @param  mixed $format  The format to serialise to
-     * @param  array $options Serialiser-specific options, for fine-tuning the output
+     * @param mixed $format  The format to serialise to
+     * @param array $options Serialiser-specific options, for fine-tuning the output
      *
-     * @return mixed  The serialised graph
+     * @return mixed The serialised graph
      */
-    public function serialise($format, array $options = array())
+    public function serialise($format, array $options = [])
     {
         if (!$format instanceof Format) {
             $format = Format::getFormat($format);
         }
         $serialiser = $format->newSerialiser();
+
         return $serialiser->serialise($this, $format->getName(), $options);
     }
 
@@ -1361,24 +1330,25 @@ class Graph
      * return a pretty-print view of all the resources and their
      * properties.
      *
-     * @param  string  $format  Either 'html' or 'text'
+     * @param string $format Either 'html' or 'text'
      *
      * @return string
      */
     public function dump($format = 'html')
     {
         $result = '';
-        if ($format == 'html') {
+        if ('html' == $format) {
             $result .= "<div style='font-family:arial; font-weight: bold; padding:0.5em; ".
                    "color: black; background-color:lightgrey;border:dashed 1px grey;'>".
-                   "Graph: ". $this->uri . "</div>\n";
+                   'Graph: '.$this->uri."</div>\n";
         } else {
-            $result .= "Graph: ". $this->uri . "\n";
+            $result .= 'Graph: '.$this->uri."\n";
         }
 
         foreach ($this->index as $resource => $properties) {
             $result .= $this->dumpResource($resource, $format);
         }
+
         return $result;
     }
 
@@ -1387,8 +1357,8 @@ class Graph
      * This method is intended to be a debugging aid and will
      * print a resource and its properties.
      *
-     * @param  mixed    $resource  The resource to dump
-     * @param  string   $format    Either 'html' or 'text'
+     * @param mixed  $resource The resource to dump
+     * @param string $format   Either 'html' or 'text'
      *
      * @return string
      */
@@ -1402,45 +1372,45 @@ class Graph
             return '';
         }
 
-        $plist = array();
+        $plist = [];
         foreach ($properties as $property => $values) {
-            $olist = array();
+            $olist = [];
             foreach ($values as $value) {
-                if ($value['type'] == 'literal') {
-                    $olist []= Utils::dumpLiteralValue($value, $format, 'black');
+                if ('literal' == $value['type']) {
+                    $olist[] = Utils::dumpLiteralValue($value, $format, 'black');
                 } else {
-                    $olist []= Utils::dumpResourceValue($value['value'], $format, 'blue');
+                    $olist[] = Utils::dumpResourceValue($value['value'], $format, 'blue');
                 }
             }
 
             $pstr = RdfNamespace::shorten($property);
-            if ($pstr == null) {
+            if (null == $pstr) {
                 $pstr = $property;
             }
-            if ($format == 'html') {
-                $plist []= "<span style='font-size:130%'>&rarr;</span> ".
+            if ('html' == $format) {
+                $plist[] = "<span style='font-size:130%'>&rarr;</span> ".
                            "<span style='text-decoration:none;color:green'>".
-                           htmlentities($pstr) . "</span> ".
+                           htmlentities($pstr).'</span> '.
                            "<span style='font-size:130%'>&rarr;</span> ".
-                           join(", ", $olist);
+                           implode(', ', $olist);
             } else {
-                $plist []= "  -> $pstr -> " . join(", ", $olist);
+                $plist[] = "  -> $pstr -> ".implode(', ', $olist);
             }
         }
 
-        if ($format == 'html') {
-            return "<div id='".htmlentities($resource, ENT_QUOTES)."' " .
+        if ('html' == $format) {
+            return "<div id='".htmlentities($resource, ENT_QUOTES)."' ".
                    "style='font-family:arial; padding:0.5em; ".
                    "background-color:lightgrey;border:dashed 1px grey;'>\n".
-                   "<div>".Utils::dumpResourceValue($resource, $format, 'blue')." ".
+                   '<div>'.Utils::dumpResourceValue($resource, $format, 'blue').' '.
                    "<span style='font-size: 0.8em'>(".
                    $this->classForResource($resource).")</span></div>\n".
                    "<div style='padding-left: 3em'>\n".
-                   "<div>".join("</div>\n<div>", $plist)."</div>".
+                   '<div>'.implode("</div>\n<div>", $plist).'</div>'.
                    "</div></div>\n";
         } else {
-            return $resource." (".$this->classForResource($resource).")\n" .
-                   join("\n", $plist) . "\n\n";
+            return $resource.' ('.$this->classForResource($resource).")\n".
+                   implode("\n", $plist)."\n\n";
         }
     }
 
@@ -1472,9 +1442,7 @@ class Graph
      * may be arbitrary.
      * This method will return null if the resource has no type.
      *
-     * @param mixed $resource
-     *
-     * @return \EasyRdf\Resource  A type associated with the resource
+     * @return \EasyRdf\Resource A type associated with the resource
      */
     public function typeAsResource($resource = null)
     {
@@ -1502,7 +1470,7 @@ class Graph
     {
         $resources = $this->typesAsResources($resource);
 
-        $types = array();
+        $types = [];
         foreach ($resources as $type) {
             $types[] = RdfNamespace::shorten($type);
         }
@@ -1515,7 +1483,7 @@ class Graph
      *
      * @param string|null $resource
      *
-     * @return Resource[]
+     * @return resource[]
      */
     public function typesAsResources($resource = null)
     {
@@ -1525,15 +1493,15 @@ class Graph
             return $this->all($resource, 'rdf:type', 'resource');
         }
 
-        return array();
+        return [];
     }
 
     /** Check if a resource is of the specified type
      *
-     * @param  string  $resource The resource to check the type of
-     * @param  string  $type     The type to check (e.g. foaf:Person)
+     * @param string $resource The resource to check the type of
+     * @param string $type     The type to check (e.g. foaf:Person)
      *
-     * @return boolean           True if resource is of specified type
+     * @return bool True if resource is of specified type
      */
     public function isA($resource, $type)
     {
@@ -1545,28 +1513,29 @@ class Graph
                 return true;
             }
         }
+
         return false;
     }
 
     /** Add one or more rdf:type properties to a resource
      *
-     * @param  string  $resource The resource to add the type to
-     * @param  string  $types    One or more types to add (e.g. foaf:Person)
+     * @param string $resource The resource to add the type to
+     * @param string $types    One or more types to add (e.g. foaf:Person)
      *
-     * @return integer           The number of types added
+     * @return int The number of types added
      */
     public function addType($resource, $types)
     {
         $this->checkResourceParam($resource, true);
 
-        if (!is_array($types)) {
-            $types = array($types);
+        if (!\is_array($types)) {
+            $types = [$types];
         }
 
         $count = 0;
         foreach ($types as $type) {
             $type = RdfNamespace::expand($type);
-            $count += $this->add($resource, 'rdf:type', array('type' => 'uri', 'value' => $type));
+            $count += $this->add($resource, 'rdf:type', ['type' => 'uri', 'value' => $type]);
         }
 
         return $count;
@@ -1577,16 +1546,17 @@ class Graph
      * Note that if the resource object has already previously
      * been created, then the PHP class of the resource will not change.
      *
-     * @param  string  $resource The resource to change the type of
-     * @param  string  $type     The new type (e.g. foaf:Person)
+     * @param string $resource The resource to change the type of
+     * @param string $type     The new type (e.g. foaf:Person)
      *
-     * @return integer           The number of types added
+     * @return int The number of types added
      */
     public function setType($resource, $type)
     {
         $this->checkResourceParam($resource, true);
 
         $this->delete($resource, 'rdf:type');
+
         return $this->addType($resource, $type);
     }
 
@@ -1600,7 +1570,7 @@ class Graph
      * @param string|null $resource
      * @param string|null $lang
      *
-     * @return string A label for the resource.
+     * @return string a label for the resource
      */
     public function label($resource = null, $lang = null)
     {
@@ -1620,9 +1590,7 @@ class Graph
 
     /** Get the primary topic of the graph
      *
-     * @param mixed $resource
-     *
-     * @return \EasyRdf\Resource  The primary topic of the document.
+     * @return \EasyRdf\Resource the primary topic of the document
      */
     public function primaryTopic($resource = null)
     {
@@ -1641,7 +1609,7 @@ class Graph
 
     /** Returns the graph as a RDF/PHP associative array
      *
-     * @return array The contents of the graph as an array.
+     * @return array the contents of the graph as an array
      */
     public function toRdfPhp()
     {
@@ -1650,16 +1618,17 @@ class Graph
 
     /** Calculates the number of triples in the graph
      *
-     * @return integer The number of triples in the graph.
+     * @return int the number of triples in the graph
      */
     public function countTriples()
     {
         $count = 0;
         foreach ($this->index as $resource) {
             foreach ($resource as $values) {
-                $count += count($values);
+                $count += \count($values);
             }
         }
+
         return $count;
     }
 
@@ -1669,7 +1638,7 @@ class Graph
      */
     public function __toString()
     {
-        return $this->uri == null ? '' : $this->uri;
+        return null == $this->uri ? '' : $this->uri;
     }
 
     /** Magic method to get a property of the graph
@@ -1680,9 +1649,10 @@ class Graph
      *   $value = $graph->title;
      *
      * @see RdfNamespace::setDefault()
-     * @param  string $name The name of the property
      *
-     * @return string       A single value for the named property
+     * @param string $name The name of the property
+     *
+     * @return string A single value for the named property
      */
     public function __get($name)
     {
@@ -1697,10 +1667,11 @@ class Graph
      *   $graph->title = 'Title';
      *
      * @see RdfNamespace::setDefault()
-     * @param  string $name The name of the property
-     * @param  string $value The value for the property
      *
-     * @return integer
+     * @param string $name  The name of the property
+     * @param string $value The value for the property
+     *
+     * @return int
      */
     public function __set($name, $value)
     {
@@ -1715,9 +1686,10 @@ class Graph
      *   if (isset($graph->title)) { blah(); }
      *
      * @see RdfNamespace::setDefault()
+     *
      * @param string $name The name of the property
      *
-     * @return boolean
+     * @return bool
      */
     public function __isset($name)
     {
@@ -1732,9 +1704,10 @@ class Graph
      *   unset($graph->title);
      *
      * @see RdfNamespace::setDefault()
+     *
      * @param string $name The name of the property
      *
-     * @return integer
+     * @return int
      */
     public function __unset($name)
     {

--- a/lib/GraphStore.php
+++ b/lib/GraphStore.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EasyRdf;
 
 /**
@@ -31,7 +32,6 @@ namespace EasyRdf;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
@@ -40,7 +40,6 @@ namespace EasyRdf;
  * A class for fetching, saving and deleting graphs to a Graph Store.
  * Implementation of the SPARQL 1.1 Graph Store HTTP Protocol.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
@@ -54,7 +53,6 @@ class GraphStore
     /** The address of the GraphStore endpoint */
     private $uri = null;
     private $parsedUri = null;
-
 
     /** Create a new SPARQL Graph Store client
      *
@@ -86,7 +84,7 @@ class GraphStore
      */
     public function get($uriRef)
     {
-        if ($uriRef === self::DEFAULT_GRAPH) {
+        if (self::DEFAULT_GRAPH === $uriRef) {
             $dataUrl = $this->urlForGraph(self::DEFAULT_GRAPH);
             $graph = new Graph();
         } else {
@@ -103,6 +101,7 @@ class GraphStore
 
     /**
      * Fetch default graph from the graph store
+     *
      * @return Graph
      */
     public function getDefault()
@@ -118,8 +117,8 @@ class GraphStore
      */
     protected function sendGraph($method, $graph, $uriRef, $format)
     {
-        if (is_object($graph) and $graph instanceof Graph) {
-            if ($uriRef === null) {
+        if (\is_object($graph) and $graph instanceof Graph) {
+            if (null === $uriRef) {
                 $uriRef = $graph->getUri();
             }
             $data = $graph->serialise($format);
@@ -127,14 +126,14 @@ class GraphStore
             $data = $graph;
         }
 
-        if ($uriRef === null) {
+        if (null === $uriRef) {
             throw new \InvalidArgumentException('Graph IRI is not specified');
         }
 
         $formatObj = Format::getFormat($format);
         $mimeType = $formatObj->getDefaultMimeType();
 
-        if ($uriRef === self::DEFAULT_GRAPH) {
+        if (self::DEFAULT_GRAPH === $uriRef) {
             $dataUrl = $this->urlForGraph(self::DEFAULT_GRAPH);
         } else {
             $graphUri = $this->parsedUri->resolve($uriRef)->toString();
@@ -151,9 +150,7 @@ class GraphStore
         $response = $client->request();
 
         if (!$response->isSuccessful()) {
-            throw new Exception(
-                "HTTP request for {$dataUrl} failed: ".$response->getMessage()
-            );
+            throw new Exception("HTTP request for {$dataUrl} failed: ".$response->getMessage());
         }
 
         return $response;
@@ -211,11 +208,11 @@ class GraphStore
      * The $format parameter can be given to specify the serialisation
      * used to send the graph data to the graph store.
      *
-     * @param Graph|string  $graph  Data
-     * @param string        $uriRef The URI of graph to be added to
-     * @param string        $format The format of the data to send to the graph store
+     * @param Graph|string $graph  Data
+     * @param string       $uriRef The URI of graph to be added to
+     * @param string       $format The format of the data to send to the graph store
      *
-     * @return Http\Response  The response from the graph store
+     * @return Http\Response The response from the graph store
      */
     public function insert($graph, $uriRef = null, $format = 'ntriples')
     {
@@ -231,10 +228,10 @@ class GraphStore
      * The $format parameter can be given to specify the serialisation
      * used to send the graph data to the graph store.
      *
-     * @param Graph|string  $graph  Data
-     * @param string        $format The format of the data to send to the graph store
+     * @param Graph|string $graph  Data
+     * @param string       $format The format of the data to send to the graph store
      *
-     * @return Http\Response  The response from the graph store
+     * @return Http\Response The response from the graph store
      */
     public function insertIntoDefault($graph, $format = 'ntriples')
     {
@@ -249,11 +246,12 @@ class GraphStore
      * @param string $uriRef The URI of graph to be added to
      *
      * @throws Exception
+     *
      * @return Http\Response The response from the graph store
      */
     public function delete($uriRef)
     {
-        if ($uriRef === self::DEFAULT_GRAPH) {
+        if (self::DEFAULT_GRAPH === $uriRef) {
             $dataUrl = $this->urlForGraph(self::DEFAULT_GRAPH);
         } else {
             $graphUri = $this->parsedUri->resolve($uriRef)->toString();
@@ -267,9 +265,7 @@ class GraphStore
         $response = $client->request();
 
         if (!$response->isSuccessful()) {
-            throw new Exception(
-                "HTTP request to delete {$dataUrl} failed: ".$response->getMessage()
-            );
+            throw new Exception("HTTP request to delete {$dataUrl} failed: ".$response->getMessage());
         }
 
         return $response;
@@ -279,6 +275,7 @@ class GraphStore
      * Delete default graph content from the graph store
      *
      * @return Http\Response
+     *
      * @throws Exception
      */
     public function deleteDefault()
@@ -288,14 +285,15 @@ class GraphStore
 
     /** Work out the full URL for a graph store request.
      *  by checking if if it is a direct or indirect request.
+     *
      *  @ignore
      */
     protected function urlForGraph($url)
     {
-        if ($url === self::DEFAULT_GRAPH) {
+        if (self::DEFAULT_GRAPH === $url) {
             $url = $this->uri.'?default';
-        } elseif (strpos($url, $this->uri) === false) {
-            $url = $this->uri."?graph=".urlencode($url);
+        } elseif (false === strpos($url, $this->uri)) {
+            $url = $this->uri.'?graph='.urlencode($url);
         }
 
         return $url;

--- a/lib/Http.php
+++ b/lib/Http.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EasyRdf;
 
 /**
@@ -31,16 +32,13 @@ namespace EasyRdf;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
 
-
 /**
  * Static class to set the HTTP client used by EasyRdf
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
@@ -51,20 +49,20 @@ class Http
 
     /** Set the HTTP Client object used to fetch RDF data
      *
-     * @param  Http\Client|\Zend\Http\Client $httpClient The new HTTP client object
+     * @param Http\Client|\Zend\Http\Client $httpClient The new HTTP client object
      *
      * @throws \InvalidArgumentException
+     *
      * @return Http\Client|\Zend\Http\Client The new HTTP client object
      */
     public static function setDefaultHttpClient($httpClient)
     {
-        if (!is_object($httpClient) or
+        if (!\is_object($httpClient) or
             !($httpClient instanceof \Zend\Http\Client or
               $httpClient instanceof Http\Client)) {
-            throw new \InvalidArgumentException(
-                '$httpClient should be an object of class Zend\Http\Client or EasyRdf\Http\Client'
-            );
+            throw new \InvalidArgumentException('$httpClient should be an object of class Zend\Http\Client or EasyRdf\Http\Client');
         }
+
         return self::$defaultHttpClient = $httpClient;
     }
 
@@ -80,6 +78,7 @@ class Http
         if (!isset(self::$defaultHttpClient)) {
             self::$defaultHttpClient = new Http\Client();
         }
+
         return self::$defaultHttpClient;
     }
 }

--- a/lib/Http/Client.php
+++ b/lib/Http/Client.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Http;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -45,7 +46,6 @@ use EasyRdf\ParsedUri;
  * It supports basic HTTP 1.0 and 1.1 requests. For a more complete
  * implementation try Zend_Http_Client.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
@@ -56,11 +56,11 @@ class Client
      *
      * @var array
      */
-    private $config = array(
-        'maxredirects'    => 5,
-        'useragent'       => 'EasyRdf HTTP Client',
-        'timeout'         => 10
-    );
+    private $config = [
+        'maxredirects' => 5,
+        'useragent' => 'EasyRdf HTTP Client',
+        'timeout' => 10,
+    ];
 
     /**
      * Request URI
@@ -74,7 +74,7 @@ class Client
      *
      * @var array
      */
-    private $headers = array();
+    private $headers = [];
 
     /**
      * HTTP request method
@@ -88,7 +88,7 @@ class Client
      *
      * @var array
      */
-    private $paramsGet = array();
+    private $paramsGet = [];
 
     /**
      * The raw post data to send. Could be set by setRawData($data).
@@ -109,14 +109,14 @@ class Client
      * URL and optionally configuration array.
      *
      * @param string $uri
-     * @param array $config Configuration key-value pairs.
+     * @param array  $config configuration key-value pairs
      */
     public function __construct($uri = null, $config = null)
     {
-        if ($uri !== null) {
+        if (null !== $uri) {
             $this->setUri($uri);
         }
-        if ($config !== null) {
+        if (null !== $config) {
             $this->setConfig($config);
         }
     }
@@ -124,21 +124,20 @@ class Client
     /**
      * Set the URI for the next request
      *
-     * @param  string $uri
+     * @param string $uri
      *
      * @throws \InvalidArgumentException
+     *
      * @return self
      */
     public function setUri($uri)
     {
-        if (!is_string($uri)) {
-            $uri = strval($uri);
+        if (!\is_string($uri)) {
+            $uri = (string) $uri;
         }
 
         if (!preg_match('/^http(s?):/', $uri)) {
-            throw new \InvalidArgumentException(
-                "EasyRdf\\Http\\Client only supports the 'http' and 'https' schemes."
-            );
+            throw new \InvalidArgumentException("EasyRdf\\Http\\Client only supports the 'http' and 'https' schemes.");
         }
 
         $this->uri = $uri;
@@ -161,17 +160,16 @@ class Client
     /**
      * Set configuration parameters for this HTTP client
      *
-     * @param  array $config
+     * @param array $config
      *
      * @return self
+     *
      * @throws \InvalidArgumentException
      */
-    public function setConfig($config = array())
+    public function setConfig($config = [])
     {
-        if ($config == null or !is_array($config)) {
-            throw new \InvalidArgumentException(
-                "\$config should be an array and cannot be null"
-            );
+        if (null == $config or !\is_array($config)) {
+            throw new \InvalidArgumentException('$config should be an array and cannot be null');
         }
 
         foreach ($config as $k => $v) {
@@ -184,7 +182,7 @@ class Client
     /**
      * Set a request header
      *
-     * @param string $name Header name (e.g. 'Accept')
+     * @param string $name  Header name (e.g. 'Accept')
      * @param string $value Header value or null
      *
      * @return self
@@ -194,11 +192,11 @@ class Client
         $normalizedName = strtolower($name);
 
         // If $value is null or false, unset the header
-        if ($value === null || $value === false) {
+        if (null === $value || false === $value) {
             unset($this->headers[$normalizedName]);
         } else {
             // Else, set the header
-            $this->headers[$normalizedName] = array($name, $value);
+            $this->headers[$normalizedName] = [$name, $value];
         }
 
         return $this;
@@ -212,12 +210,13 @@ class Client
      * @param string $method
      *
      * @return self
+     *
      * @throws \InvalidArgumentException
      */
     public function setMethod($method)
     {
-        if (!is_string($method) or !preg_match('/^[A-Z]+$/', $method)) {
-            throw new \InvalidArgumentException("Invalid HTTP request method.");
+        if (!\is_string($method) or !preg_match('/^[A-Z]+$/', $method)) {
+            throw new \InvalidArgumentException('Invalid HTTP request method.');
         }
 
         $this->method = $method;
@@ -265,7 +264,7 @@ class Client
      */
     public function setParameterGet($name, $value = null)
     {
-        if ($value === null) {
+        if (null === $value) {
             if (isset($this->paramsGet[$name])) {
                 unset($this->paramsGet[$name]);
             }
@@ -329,6 +328,7 @@ class Client
     public function setRawData($data)
     {
         $this->rawPostData = $data;
+
         return $this;
     }
 
@@ -358,12 +358,12 @@ class Client
     public function resetParameters($clearAll = false)
     {
         // Reset parameter data
-        $this->paramsGet   = array();
+        $this->paramsGet = [];
         $this->rawPostData = null;
-        $this->method      = 'GET';
+        $this->method = 'GET';
 
         if ($clearAll) {
-            $this->headers = array();
+            $this->headers = [];
         } else {
             // Clear outdated headers
             if (isset($this->headers['content-type'])) {
@@ -380,17 +380,16 @@ class Client
     /**
      * Send the HTTP request and return an HTTP response object
      *
-     * @param null|string $method
+     * @param string|null $method
      *
      * @throws \EasyRdf\Exception
+     *
      * @return Response
      */
     public function request($method = null)
     {
         if (!$this->uri) {
-            throw new Exception(
-                "Set URI before calling Client->request()"
-            );
+            throw new Exception('Set URI before calling Client->request()');
         }
 
         if ($method) {
@@ -403,20 +402,18 @@ class Client
         do {
             // Clone the URI and add the additional GET parameters to it
             $uri = parse_url($this->uri);
-            if ($uri['scheme'] === 'http') {
+            if ('http' === $uri['scheme']) {
                 $host = $uri['host'];
-            } elseif ($uri['scheme'] === 'https') {
+            } elseif ('https' === $uri['scheme']) {
                 $host = 'ssl://'.$uri['host'];
             } else {
-                throw new Exception(
-                    "Unsupported URI scheme: ".$uri['scheme']
-                );
+                throw new Exception('Unsupported URI scheme: '.$uri['scheme']);
             }
 
             if (isset($uri['port'])) {
                 $port = $uri['port'];
             } else {
-                if ($uri['scheme'] === 'https') {
+                if ('https' === $uri['scheme']) {
                     $port = 443;
                 } else {
                     $port = 80;
@@ -448,12 +445,12 @@ class Client
                 $path = '/';
             }
             if (isset($uri['query'])) {
-                $path .= '?' . $uri['query'];
+                $path .= '?'.$uri['query'];
             }
             fwrite($socket, "{$this->method} {$path} HTTP/1.1\r\n");
             foreach ($headers as $k => $v) {
-                if (is_string($k)) {
-                    $v = ucfirst($k) . ": $v";
+                if (\is_string($k)) {
+                    $v = ucfirst($k).": $v";
                 }
                 fwrite($socket, "$v\r\n");
             }
@@ -487,7 +484,6 @@ class Client
             if ($response->isRedirect() &&
                    ($location = $response->getHeader('location'))
                ) {
-
                 // Avoid problems with buggy servers that add whitespace at the
                 // end of some headers (See ZF-11283)
                 $location = trim($location);
@@ -498,7 +494,7 @@ class Client
                 $location = $baseUri->resolve($location)->toString();
 
                 // If it is a 303 then drop the parameters and send a GET request
-                if ($response->getStatus() == 303) {
+                if (303 == $response->getStatus()) {
                     $this->resetParameters();
                     $this->setMethod('GET');
                 }
@@ -508,19 +504,13 @@ class Client
                     $this->setHeaders('host', null);
                     $this->setUri($location);
                 } else {
-                    throw new Exception(
-                        "Failed to parse Location header returned by ".
-                        $this->uri
-                    );
+                    throw new Exception('Failed to parse Location header returned by '.$this->uri);
                 }
                 ++$this->redirectCounter;
-
             } else {
                 // If we didn't get any location, stop redirecting
                 break;
             }
-
-
         } while ($this->redirectCounter < $this->config['maxredirects']);
 
         return $response;
@@ -538,36 +528,36 @@ class Client
      */
     protected function prepareHeaders($host, $port)
     {
-        $headers = array();
+        $headers = [];
 
         // Set the host header
-        if (! isset($this->headers['host'])) {
+        if (!isset($this->headers['host'])) {
             // If the port is not default, add it
-            if ($port !== 80 and $port !== 443) {
-                $host .= ':' . $port;
+            if (80 !== $port and 443 !== $port) {
+                $host .= ':'.$port;
             }
             $headers[] = "Host: {$host}";
         }
 
         // Set the connection header
-        if (! isset($this->headers['connection'])) {
-            $headers[] = "Connection: close";
+        if (!isset($this->headers['connection'])) {
+            $headers[] = 'Connection: close';
         }
 
         // Set the user agent header
-        if (! isset($this->headers['user-agent'])) {
+        if (!isset($this->headers['user-agent'])) {
             $headers[] = "User-Agent: {$this->config['useragent']}";
         }
 
         // If we have rawPostData set, set the content-length header
         if (isset($this->rawPostData)) {
-            $headers[] = "Content-Length: ".strlen($this->rawPostData);
+            $headers[] = 'Content-Length: '.\strlen($this->rawPostData);
         }
 
         // Add all other user defined headers
         foreach ($this->headers as $header) {
             list($name, $value) = $header;
-            if (is_array($value)) {
+            if (\is_array($value)) {
                 $value = implode(', ', $value);
             }
 

--- a/lib/Http/Exception.php
+++ b/lib/Http/Exception.php
@@ -1,11 +1,12 @@
 <?php
+
 namespace EasyRdf\Http;
 
 class Exception extends \EasyRdf\Exception
 {
     private $body;
 
-    public function __construct($message = "", $code = 0, \Exception $previous = null, $body = '')
+    public function __construct($message = '', $code = 0, \Exception $previous = null, $body = '')
     {
         parent::__construct($message, $code, $previous);
         $this->body = $body;

--- a/lib/Http/Response.php
+++ b/lib/Http/Response.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Http;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -43,14 +44,12 @@ use EasyRdf\Exception;
 /**
  * Class that represents an HTTP 1.0 / 1.1 response message.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  *             Copyright (c) 2005-2009 Zend Technologies USA Inc.
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
 class Response
 {
-
     /**
      * The HTTP response status code
      *
@@ -71,7 +70,7 @@ class Response
      *
      * @var array
      */
-    private $headers = array();
+    private $headers = [];
 
     /**
      * The HTTP response body
@@ -83,11 +82,11 @@ class Response
     /**
      * Constructor.
      *
-     * @param  int     $status HTTP Status code
-     * @param  array   $headers The HTTP response headers
-     * @param  string  $body The content of the response
-     * @param  string  $version The HTTP Version (1.0 or 1.1)
-     * @param  string  $message The HTTP response Message
+     * @param int    $status  HTTP Status code
+     * @param array  $headers The HTTP response headers
+     * @param string $body    The content of the response
+     * @param string $version The HTTP Version (1.0 or 1.1)
+     * @param string $message The HTTP response Message
      */
     public function __construct(
         $status,
@@ -110,31 +109,31 @@ class Response
     /**
      * Check whether the response in successful
      *
-     * @return boolean
+     * @return bool
      */
     public function isSuccessful()
     {
-        return ($this->status >= 200 && $this->status < 300);
+        return $this->status >= 200 && $this->status < 300;
     }
 
     /**
      * Check whether the response is an error
      *
-     * @return boolean
+     * @return bool
      */
     public function isError()
     {
-        return ($this->status >= 400 && $this->status < 600);
+        return $this->status >= 400 && $this->status < 600;
     }
 
     /**
      * Check whether the response is a redirection
      *
-     * @return boolean
+     * @return bool
      */
     public function isRedirect()
     {
-        return ($this->status >= 300 && $this->status < 400);
+        return $this->status >= 300 && $this->status < 400;
     }
 
     /**
@@ -225,7 +224,7 @@ class Response
     public function getHeader($header)
     {
         $header = ucwords(strtolower($header));
-        if (array_key_exists($header, $this->headers)) {
+        if (\array_key_exists($header, $this->headers)) {
             return $this->headers[$header];
         }
 
@@ -235,8 +234,8 @@ class Response
     /**
      * Get all headers as string
      *
-     * @param boolean $statusLine Whether to return the first status line (ie "HTTP 200 OK")
-     * @param string  $br         Line breaks (eg. "\n", "\r\n", "<br />")
+     * @param bool   $statusLine Whether to return the first status line (ie "HTTP 200 OK")
+     * @param string $br         Line breaks (eg. "\n", "\r\n", "<br />")
      *
      * @return string
      */
@@ -250,9 +249,9 @@ class Response
 
         // Iterate over the headers and stringify them
         foreach ($this->headers as $name => $value) {
-            if (is_string($value)) {
+            if (\is_string($value)) {
                 $str .= "{$name}: {$value}{$br}";
-            } elseif (is_array($value)) {
+            } elseif (\is_array($value)) {
                 foreach ($value as $subval) {
                     $str .= "{$name}: {$subval}{$br}";
                 }
@@ -268,18 +267,17 @@ class Response
      * @param string $responseStr
      *
      * @throws \EasyRdf\Exception
+     *
      * @return self
      */
     public static function fromString($responseStr)
     {
         // First, split body and headers
         $matches = preg_split('|(?:\r?\n){2}|m', $responseStr, 2);
-        if ($matches and 2 === count($matches)) {
-            list ($headerLines, $body) = $matches;
+        if ($matches and 2 === \count($matches)) {
+            list($headerLines, $body) = $matches;
         } else {
-            throw new Exception(
-                "Failed to parse HTTP response."
-            );
+            throw new Exception('Failed to parse HTTP response.');
         }
 
         // Split headers part to lines
@@ -290,21 +288,19 @@ class Response
             $status = $m[2];
             $message = $m[3];
         } else {
-            throw new Exception(
-                "Failed to parse HTTP response status line."
-            );
+            throw new Exception('Failed to parse HTTP response status line.');
         }
 
         // Process the rest of the header lines
-        $headers = array();
+        $headers = [];
         foreach ($headerLines as $line) {
             if (preg_match("|^([\w-]+):\s+(.+)$|", $line, $m)) {
                 $hName = ucwords(strtolower($m[1]));
                 $hValue = $m[2];
 
                 if (isset($headers[$hName])) {
-                    if (! is_array($headers[$hName])) {
-                        $headers[$hName] = array($headers[$hName]);
+                    if (!\is_array($headers[$hName])) {
+                        $headers[$hName] = [$headers[$hName]];
                     }
                     $headers[$hName][] = $hValue;
                 } else {
@@ -315,7 +311,6 @@ class Response
 
         return new self($status, $headers, $body, $version, $message);
     }
-
 
     /**
      * Decode a "chunked" transfer-encoded body and return the decoded text
@@ -332,14 +327,12 @@ class Response
 
         while (trim($body)) {
             if (!preg_match("/^([\da-fA-F]+)[^\r\n]*\r\n/sm", $body, $m)) {
-                throw new Exception(
-                    "Error parsing body - doesn't seem to be a chunked message"
-                );
+                throw new Exception("Error parsing body - doesn't seem to be a chunked message");
             }
-            $length   = hexdec(trim($m[1]));
-            $cut      = strlen($m[0]);
+            $length = hexdec(trim($m[1]));
+            $cut = \strlen($m[0]);
             $decBody .= substr($body, $cut, $length);
-            $body     = substr($body, $cut + $length + 2);
+            $body = substr($body, $cut + $length + 2);
         }
 
         return $decBody;
@@ -358,10 +351,8 @@ class Response
      */
     public static function decodeGzip($body)
     {
-        if (!function_exists('gzinflate')) {
-            throw new Exception(
-                'zlib extension is required in order to decode "gzip" encoding'
-            );
+        if (!\function_exists('gzinflate')) {
+            throw new Exception('zlib extension is required in order to decode "gzip" encoding');
         }
 
         return gzinflate(substr($body, 10));
@@ -380,10 +371,8 @@ class Response
      */
     public static function decodeDeflate($body)
     {
-        if (!function_exists('gzuncompress')) {
-            throw new Exception(
-                'zlib extension is required in order to decode "deflate" encoding'
-            );
+        if (!\function_exists('gzuncompress')) {
+            throw new Exception('zlib extension is required in order to decode "deflate" encoding');
         }
 
         /**
@@ -395,7 +384,7 @@ class Response
          *
          * This method was adapted from PEAR HTTP_Request2 by (c) Alexey Borzov
          *
-         * @link http://framework.zend.com/issues/browse/ZF-6040
+         * @see http://framework.zend.com/issues/browse/ZF-6040
          */
         $zlibHeader = unpack('n', substr($body, 0, 2));
 
@@ -406,7 +395,6 @@ class Response
         return gzinflate($body);
     }
 
-
     /**
      * Get the entire response as string
      *
@@ -416,7 +404,7 @@ class Response
      */
     public function asString($br = "\n")
     {
-        return $this->getHeadersAsString(true, $br) . $br . $this->getRawBody();
+        return $this->getHeadersAsString(true, $br).$br.$this->getRawBody();
     }
 
     /**

--- a/lib/Isomorphic.php
+++ b/lib/Isomorphic.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EasyRdf;
 
 /**
@@ -31,7 +32,6 @@ namespace EasyRdf;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
@@ -42,7 +42,6 @@ namespace EasyRdf;
  * Based on rdf-isomorphic.rb by Ben Lavender:
  * https://github.com/ruby-rdf/rdf-isomorphic
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
@@ -56,14 +55,14 @@ class Isomorphic
      *    $graphB = EasyRdf\Graph::newAndLoad('http://example.com/b.ttl');
      *    if (EasyRdf\Isomorphic::isomorphic($graphA, $graphB)) print "Equal!";
      *
-     * @param  Graph  $graphA  The first graph to be compared
-     * @param  Graph  $graphB  The second graph to be compared
+     * @param Graph $graphA The first graph to be compared
+     * @param Graph $graphB The second graph to be compared
      *
-     * @return boolean True if the two graphs are isomorphic
+     * @return bool True if the two graphs are isomorphic
      */
     public static function isomorphic($graphA, $graphB)
     {
-        return is_array(self::bijectionBetween($graphA, $graphB));
+        return \is_array(self::bijectionBetween($graphA, $graphB));
     }
 
     /**
@@ -71,17 +70,17 @@ class Isomorphic
      * bijection of one EasyRdf\Graph to another EasyRdf\Graph's blank nodes or
      * null if a bijection cannot be found.
      *
-     * @param  Graph  $graphA  The first graph to be compared
-     * @param  Graph  $graphB  The second graph to be compared
+     * @param Graph $graphA The first graph to be compared
+     * @param Graph $graphB The second graph to be compared
      *
-     * @return array|null  bnode mapping from $graphA to $graphB
+     * @return array|null bnode mapping from $graphA to $graphB
      */
     public static function bijectionBetween($graphA, $graphB)
     {
-        $bnodesA = array();
-        $bnodesB = array();
-        $statementsA = array();
-        $statementsB = array();
+        $bnodesA = [];
+        $bnodesB = [];
+        $statementsA = [];
+        $statementsB = [];
 
         // Quick initial check: are there differing numbers of subjects?
         if (self::countSubjects($graphA) != self::countSubjects($graphB)) {
@@ -96,29 +95,31 @@ class Isomorphic
             $groundedStatementsMatch = self::groundedStatementsMatch($graphB, $graphA, $bnodesB, $statementsB);
         }
 
-        if ($groundedStatementsMatch === false) {
+        if (false === $groundedStatementsMatch) {
             // The grounded statements do not match
             return null;
-        } elseif (count($bnodesA) > 0 or count($bnodesB) > 0) {
+        } elseif (\count($bnodesA) > 0 or \count($bnodesB) > 0) {
             // There are blank nodes - build a bi-jection
             return self::buildBijectionTo($statementsA, $bnodesA, $statementsB, $bnodesB);
         } else {
             // No bnodes and the grounded statements match
-            return array();
+            return [];
         }
     }
 
     /**
      * Count the number of subjects in a graph
+     *
      * @ignore
      */
     private static function countSubjects($graph)
     {
-        return count($graph->toRdfPhp());
+        return \count($graph->toRdfPhp());
     }
 
     /**
      * Check if all the statements in $graphA also appear in $graphB
+     *
      * @ignore
      */
     private static function groundedStatementsMatch($graphA, $graphB, &$bnodes, &$anonStatements)
@@ -126,7 +127,7 @@ class Isomorphic
         $groundedStatementsMatch = true;
 
         foreach ($graphA->toRdfPhp() as $subject => $properties) {
-            if (substr($subject, 0, 2) == '_:') {
+            if ('_:' == substr($subject, 0, 2)) {
                 array_push($bnodes, $subject);
                 $subjectIsBnode = true;
             } else {
@@ -135,7 +136,7 @@ class Isomorphic
 
             foreach ($properties as $property => $values) {
                 foreach ($values as $value) {
-                    if ($value['type'] == 'uri' and substr($value['value'], 0, 2) == '_:') {
+                    if ('uri' == $value['type'] and '_:' == substr($value['value'], 0, 2)) {
                         array_push($bnodes, $value['value']);
                         $objectIsBnode = true;
                     } else {
@@ -143,9 +144,9 @@ class Isomorphic
                     }
 
                     if ($groundedStatementsMatch and
-                        $subjectIsBnode === false and
-                        $objectIsBnode === false and
-                        $graphB->hasProperty($subject, $property, $value) === false
+                        false === $subjectIsBnode and
+                        false === $objectIsBnode and
+                        false === $graphB->hasProperty($subject, $property, $value)
                     ) {
                         $groundedStatementsMatch = false;
                     }
@@ -153,11 +154,11 @@ class Isomorphic
                     if ($subjectIsBnode or $objectIsBnode) {
                         array_push(
                             $anonStatements,
-                            array(
-                                array('type' => $subjectIsBnode ? 'bnode' : 'uri', 'value' => $subject),
-                                array('type' => 'uri', 'value' => $property),
-                                $value
-                            )
+                            [
+                                ['type' => $subjectIsBnode ? 'bnode' : 'uri', 'value' => $subject],
+                                ['type' => 'uri', 'value' => $property],
+                                $value,
+                            ]
                         );
                     }
                 }
@@ -176,16 +177,14 @@ class Isomorphic
      *
      * @ignore
      */
-    private static function buildBijectionTo
-    (
+    private static function buildBijectionTo(
         $statementsA,
         $nodesA,
         $statementsB,
         $nodesB,
-        $groundedHashesA = array(),
-        $groundedHashesB = array()
+        $groundedHashesA = [],
+        $groundedHashesB = []
     ) {
-
         // Create a hash signature of every node, based on the signature of
         // statements it exists in.
         // We also save hashes of nodes that cannot be reliably known; we will use
@@ -202,12 +201,12 @@ class Isomorphic
         // middle of the method, and probably slows down isomorphic checks,  but
         // prevents almost-isomorphic cases from getting nutty.
         foreach ($hashesA as $hashA) {
-            if (!in_array($hashA, $hashesB)) {
+            if (!\in_array($hashA, $hashesB)) {
                 return null;
             }
         }
         foreach ($hashesB as $hashB) {
-            if (!in_array($hashB, $hashesA)) {
+            if (!\in_array($hashB, $hashesA)) {
                 return null;
             }
         }
@@ -215,7 +214,7 @@ class Isomorphic
         // Using the created hashes, map nodes to other_nodes
         // Ungrounded hashes will also be equal, but we keep the distinction
         // around for when we recurse later (we only recurse on ungrounded nodes)
-        $bijection = array();
+        $bijection = [];
         foreach ($nodesA as $nodeA) {
             $foundNode = null;
             foreach ($ungroundedHashesB as $nodeB => $hashB) {
@@ -248,7 +247,6 @@ class Isomorphic
             $bijection = null;
 
             foreach ($nodesA as $nodeA) {
-
                 // We don't replace grounded nodes' hashes
                 if (isset($hashesA[$nodeA])) {
                     continue;
@@ -299,14 +297,14 @@ class Isomorphic
     private static function hashNodes($statements, $nodes, $groundedHahes)
     {
         $hashes = $groundedHahes;
-        $ungroundedHashes = array();
+        $ungroundedHashes = [];
         $hashNeeded = true;
 
         // We may have to go over the list multiple times.  If a node is marked as
         // grounded, other nodes can then use it to decide their own state of
         // grounded.
         while ($hashNeeded) {
-            $startingGroundedNodes = count($hashes);
+            $startingGroundedNodes = \count($hashes);
             foreach ($nodes as $node) {
                 if (!isset($hashes[$node])) {
                     $hash = self::nodeHashFor($node, $statements, $hashes);
@@ -319,7 +317,7 @@ class Isomorphic
 
             // after going over the list, any nodes with a unique hash can be marked
             // as grounded, even if we have not tied them back to a root yet.
-            $uniques = array();
+            $uniques = [];
             foreach ($ungroundedHashes as $node => $hash) {
                 $uniques[$hash] = isset($uniques[$hash]) ? false : $node;
             }
@@ -328,10 +326,10 @@ class Isomorphic
                     $hashes[$node] = $hash;
                 }
             }
-            $hashNeeded = ($startingGroundedNodes != count($hashes));
+            $hashNeeded = ($startingGroundedNodes != \count($hashes));
         }
 
-        return array($hashes, $ungroundedHashes);
+        return [$hashes, $ungroundedHashes];
     }
 
     /**
@@ -352,10 +350,10 @@ class Isomorphic
      */
     private static function nodeHashFor($node, $statements, $hashes)
     {
-        $statement_signatures = array();
+        $statement_signatures = [];
         foreach ($statements as $statement) {
             foreach ($statement as $n) {
-                if ($n['type'] != 'literal' and $n['value'] == $node) {
+                if ('literal' != $n['type'] and $n['value'] == $node) {
                     array_push(
                         $statement_signatures,
                         self::hashStringFor($statement, $hashes, $node)
@@ -383,9 +381,9 @@ class Isomorphic
     {
         $grounded = true;
         foreach ($statements as $statement) {
-            if (in_array($node, $statement)) {
+            if (\in_array($node, $statement)) {
                 foreach ($statement as $resource) {
-                    if ($node['type'] != 'bnode' or
+                    if ('bnode' != $node['type'] or
                         isset($hashes[$node['value']]) or
                         $resource == $node
                     ) {
@@ -394,6 +392,7 @@ class Isomorphic
                 }
             }
         }
+
         return $grounded;
     }
 
@@ -405,10 +404,11 @@ class Isomorphic
      */
     private static function hashStringFor($statement, $hashes, $node)
     {
-        $str = "";
+        $str = '';
         foreach ($statement as $r) {
             $str .= self::stringForNode($r, $hashes, $node);
         }
+
         return $str;
     }
 
@@ -421,18 +421,19 @@ class Isomorphic
      */
     private static function stringForNode($node, $hashes, $target)
     {
-        if (is_null($node)) {
-            return "";
-        } elseif ($node['type'] == 'bnode') {
+        if (null === $node) {
+            return '';
+        } elseif ('bnode' == $node['type']) {
             if ($node['value'] == $target) {
-                return "itself";
+                return 'itself';
             } elseif (isset($hashes[$node['value']])) {
                 return $hashes[$node['value']];
             } else {
-                return "a blank node";
+                return 'a blank node';
             }
         } else {
             $s = new Serialiser\Ntriples();
+
             return $s->serialiseValue($node);
         }
     }

--- a/lib/Literal.php
+++ b/lib/Literal.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EasyRdf;
 
 /**
@@ -31,7 +32,6 @@ namespace EasyRdf;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
@@ -39,17 +39,16 @@ namespace EasyRdf;
 /**
  * Class that represents an RDF Literal
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
 class Literal
 {
     /** @ignore a mapping from datatype uri to class name */
-    private static $datatypeMap = array();
+    private static $datatypeMap = [];
 
     /** @ignore A mapping from class name to datatype URI */
-    private static $classMap = array();
+    private static $classMap = [];
 
     /** @ignore The string value for this literal */
     protected $value = null;
@@ -59,7 +58,6 @@ class Literal
 
     /** @ignore The datatype URI of the literal */
     protected $datatype = null;
-
 
     /** Create a new literal object
      *
@@ -72,11 +70,11 @@ class Literal
      * Note that literals are not required to have a language or datatype.
      * Literals cannot have both a language and a datatype.
      *
-     * @param  mixed  $value     The value of the literal or an associative array
-     * @param  string $lang      The natural language of the literal or null (e.g. 'en')
-     * @param  string $datatype  The datatype of the literal or null (e.g. 'xsd:integer')
+     * @param mixed  $value    The value of the literal or an associative array
+     * @param string $lang     The natural language of the literal or null (e.g. 'en')
+     * @param string $datatype The datatype of the literal or null (e.g. 'xsd:integer')
      *
-     * @return self  (or subclass of EasyRdf\Literal)
+     * @return self (or subclass of EasyRdf\Literal)
      */
     public static function create($value, $lang = null, $datatype = null)
     {
@@ -92,13 +90,13 @@ class Literal
             $value = isset($value['value']) ? $value['value'] : null;
         }
 
-        if (is_null($datatype) or $datatype === '') {
-            if (is_null($lang) or $lang === '') {
+        if (null === $datatype or '' === $datatype) {
+            if (null === $lang or '' === $lang) {
                 // Automatic datatype selection
                 $datatype = self::getDatatypeForValue($value);
             }
-        } elseif (is_object($datatype)) {
-            $datatype = strval($datatype);
+        } elseif (\is_object($datatype)) {
+            $datatype = (string) $datatype;
         } else {
             // Expand shortened URIs (qnames)
             $datatype = RdfNamespace::expand($datatype);
@@ -110,6 +108,7 @@ class Literal
         } else {
             $class = 'EasyRdf\Literal';
         }
+
         return new $class($value, $lang, $datatype);
     }
 
@@ -124,23 +123,19 @@ class Literal
      * Example:
      * EasyRdf\Literal::registerDatatype('xsd:dateTime', 'My_DateTime_Class');
      *
-     * @param  string  $datatype   The RDF datatype (e.g. xsd:dateTime)
-     * @param  string  $class      The PHP class name (e.g. My_DateTime_Class)
+     * @param string $datatype The RDF datatype (e.g. xsd:dateTime)
+     * @param string $class    The PHP class name (e.g. My_DateTime_Class)
      *
      * @throws \InvalidArgumentException
      */
     public static function setDatatypeMapping($datatype, $class)
     {
-        if (!is_string($datatype) or $datatype == null or $datatype == '') {
-            throw new \InvalidArgumentException(
-                "\$datatype should be a string and cannot be null or empty"
-            );
+        if (!\is_string($datatype) or null == $datatype or '' == $datatype) {
+            throw new \InvalidArgumentException('$datatype should be a string and cannot be null or empty');
         }
 
-        if (!is_string($class) or $class == null or $class == '') {
-            throw new \InvalidArgumentException(
-                "\$class should be a string and cannot be null or empty"
-            );
+        if (!\is_string($class) or null == $class or '' == $class) {
+            throw new \InvalidArgumentException('$class should be a string and cannot be null or empty');
         }
 
         $datatype = RdfNamespace::expand($datatype);
@@ -150,16 +145,14 @@ class Literal
 
     /** Remove the mapping between an RDF datatype and a PHP class name
      *
-     * @param  string  $datatype   The RDF datatype (e.g. xsd:dateTime)
+     * @param string $datatype The RDF datatype (e.g. xsd:dateTime)
      *
      * @throws \InvalidArgumentException
      */
     public static function deleteDatatypeMapping($datatype)
     {
-        if (!is_string($datatype) or $datatype == null or $datatype == '') {
-            throw new \InvalidArgumentException(
-                "\$datatype should be a string and cannot be null or empty"
-            );
+        if (!\is_string($datatype) or null == $datatype or '' == $datatype) {
+            throw new \InvalidArgumentException('$datatype should be a string and cannot be null or empty');
         }
 
         $datatype = RdfNamespace::expand($datatype);
@@ -177,32 +170,28 @@ class Literal
      * URI for that value, for example:
      * http://www.w3.org/2001/XMLSchema#integer
      *
-     * @param mixed $value
-     *
-     * @return string  A URI for the datatype of $value.
+     * @return string a URI for the datatype of $value
      */
     public static function getDatatypeForValue($value)
     {
-        if (is_float($value)) {
+        if (\is_float($value)) {
             return 'http://www.w3.org/2001/XMLSchema#double';
-        } elseif (is_int($value)) {
+        } elseif (\is_int($value)) {
             return 'http://www.w3.org/2001/XMLSchema#integer';
-        } elseif (is_bool($value)) {
+        } elseif (\is_bool($value)) {
             return 'http://www.w3.org/2001/XMLSchema#boolean';
-        } elseif (is_object($value) and $value instanceof \DateTime) {
+        } elseif (\is_object($value) and $value instanceof \DateTime) {
             return 'http://www.w3.org/2001/XMLSchema#dateTime';
         } else {
             return null;
         }
     }
 
-
-
     /** Constructor for creating a new literal
      *
-     * @param  string $value     The value of the literal
-     * @param  string $lang      The natural language of the literal or null (e.g. 'en')
-     * @param  string $datatype  The datatype of the literal or null (e.g. 'xsd:string')
+     * @param string $value    The value of the literal
+     * @param string $lang     The natural language of the literal or null (e.g. 'en')
+     * @param string $datatype The datatype of the literal or null (e.g. 'xsd:string')
      *
      * @return Literal
      */
@@ -213,9 +202,9 @@ class Literal
         $this->datatype = $datatype ? $datatype : null;
 
         if ($this->datatype) {
-            if (is_object($this->datatype)) {
+            if (\is_object($this->datatype)) {
                 // Convert objects to strings
-                $this->datatype = strval($this->datatype);
+                $this->datatype = (string) ($this->datatype);
             } else {
                 // Expand shortened URIs (CURIEs)
                 $this->datatype = RdfNamespace::expand($this->datatype);
@@ -225,14 +214,14 @@ class Literal
             $this->lang = null;
         } else {
             // Set the datatype based on the subclass
-            $class = get_class($this);
+            $class = static::class;
             if (isset(self::$classMap[$class])) {
                 $this->datatype = self::$classMap[$class];
                 $this->lang = null;
             }
         }
 
-        if (is_float($this->value)) {
+        if (\is_float($this->value)) {
             // special handling of floats, as they suffer from locale [mis]configuration
             $this->value = rtrim(sprintf('%F', $this->value), '0');
         } else {
@@ -243,7 +232,7 @@ class Literal
 
     /** Returns the value of the literal.
      *
-     * @return string  Value of this literal.
+     * @return string value of this literal
      */
     public function getValue()
     {
@@ -252,7 +241,7 @@ class Literal
 
     /** Returns the full datatype URI of the literal.
      *
-     * @return string  Datatype URI of this literal.
+     * @return string datatype URI of this literal
      */
     public function getDatatypeUri()
     {
@@ -261,7 +250,7 @@ class Literal
 
     /** Returns the shortened datatype URI of the literal.
      *
-     * @return string  Datatype of this literal (e.g. xsd:integer).
+     * @return string Datatype of this literal (e.g. xsd:integer).
      */
     public function getDatatype()
     {
@@ -274,7 +263,7 @@ class Literal
 
     /** Returns the language of the literal.
      *
-     * @return string  Language of this literal.
+     * @return string language of this literal
      */
     public function getLang()
     {
@@ -286,14 +275,14 @@ class Literal
      * For example:
      * array('type' => 'literal', 'value' => 'string value')
      *
-     * @return array  The properties of the literal
+     * @return array The properties of the literal
      */
     public function toRdfPhp()
     {
-        $array = array(
+        $array = [
             'type' => 'literal',
-            'value' => $this->value
-        );
+            'value' => $this->value,
+        ];
 
         if ($this->datatype) {
             $array['datatype'] = $this->datatype;
@@ -317,8 +306,8 @@ class Literal
 
     /** Return pretty-print view of the literal
      *
-     * @param  string $format Either 'html' or 'text'
-     * @param  string $color  The colour of the text
+     * @param string $format Either 'html' or 'text'
+     * @param string $color  The colour of the text
      *
      * @return string
      */

--- a/lib/Literal/Boolean.php
+++ b/lib/Literal/Boolean.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Literal;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -40,8 +41,8 @@ use EasyRdf\Literal;
 /**
  * Class that represents an RDF Literal of datatype xsd:boolean
  *
- * @package    EasyRdf
- * @link       http://www.w3.org/TR/xmlschema-2/#boolean
+ * @see       http://www.w3.org/TR/xmlschema-2/#boolean
+ *
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
@@ -51,13 +52,13 @@ class Boolean extends Literal
      *
      * If the value is not a string, then it will be converted to 'true' or 'false'.
      *
-     * @param  mixed  $value    The value of the literal
-     * @param  string $lang     Should be null (literals with a datatype can't have a language)
-     * @param  string $datatype Optional datatype (default 'xsd:boolean')
+     * @param mixed  $value    The value of the literal
+     * @param string $lang     Should be null (literals with a datatype can't have a language)
+     * @param string $datatype Optional datatype (default 'xsd:boolean')
      */
     public function __construct($value, $lang = null, $datatype = null)
     {
-        if (!is_string($value)) {
+        if (!\is_string($value)) {
             $value = $value ? 'true' : 'false';
         }
         parent::__construct($value, null, $datatype);
@@ -71,7 +72,7 @@ class Boolean extends Literal
      */
     public function getValue()
     {
-        return strtolower($this->value) === 'true' or $this->value === '1';
+        return 'true' === strtolower($this->value) or '1' === $this->value;
     }
 
     /** Return true if the value of the literal is 'true' or '1'
@@ -80,7 +81,7 @@ class Boolean extends Literal
      */
     public function isTrue()
     {
-        return strtolower($this->value) === 'true' or $this->value === '1';
+        return 'true' === strtolower($this->value) or '1' === $this->value;
     }
 
     /** Return true if the value of the literal is 'false' or '0'
@@ -89,6 +90,6 @@ class Boolean extends Literal
      */
     public function isFalse()
     {
-        return strtolower($this->value) === 'false' or $this->value === '0';
+        return 'false' === strtolower($this->value) or '0' === $this->value;
     }
 }

--- a/lib/Literal/Date.php
+++ b/lib/Literal/Date.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Literal;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -40,8 +41,8 @@ use EasyRdf\Literal;
 /**
  * Class that represents an RDF Literal of datatype xsd:date
  *
- * @package    EasyRdf
- * @link       http://www.w3.org/TR/xmlschema-2/#date
+ * @see       http://www.w3.org/TR/xmlschema-2/#date
+ *
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
@@ -54,14 +55,14 @@ class Date extends Literal
      *
      * @see \DateTime
      *
-     * @param  mixed  $value     The value of the literal
-     * @param  string $lang      Should be null (literals with a datatype can't have a language)
-     * @param  string $datatype  Optional datatype (default 'xsd:date')
+     * @param mixed  $value    The value of the literal
+     * @param string $lang     Should be null (literals with a datatype can't have a language)
+     * @param string $datatype Optional datatype (default 'xsd:date')
      */
     public function __construct($value = null, $lang = null, $datatype = null)
     {
         // If $value is null, use today's date
-        if (is_null($value)) {
+        if (null === $value) {
             $value = new \DateTime('today');
         }
 
@@ -79,6 +80,7 @@ class Date extends Literal
      *   $date = EasyRdf\Literal\Date::parse('1 January 2011');
      *
      * @see DateTime
+     *
      * @param string $value The date to parse
      *
      * @return self
@@ -86,12 +88,14 @@ class Date extends Literal
     public static function parse($value)
     {
         $value = new \DateTime($value);
+
         return new self($value);
     }
 
     /** Returns the date as a PHP DateTime object
      *
      * @see DateTime::format
+     *
      * @return string
      */
     public function getValue()
@@ -102,6 +106,7 @@ class Date extends Literal
     /** Returns date formatted according to given format
      *
      * @see DateTime::format
+     *
      * @param string $format
      *
      * @return string
@@ -113,28 +118,28 @@ class Date extends Literal
 
     /** A full integer representation of the year, 4 digits
      *
-     * @return integer
+     * @return int
      */
     public function year()
     {
-        return (int)$this->format('Y');
+        return (int) $this->format('Y');
     }
 
     /** Integer representation of the month
      *
-     * @return integer
+     * @return int
      */
     public function month()
     {
-        return (int)$this->format('m');
+        return (int) $this->format('m');
     }
 
     /** Integer representation of the day of the month
      *
-     * @return integer
+     * @return int
      */
     public function day()
     {
-        return (int)$this->format('d');
+        return (int) $this->format('d');
     }
 }

--- a/lib/Literal/DateTime.php
+++ b/lib/Literal/DateTime.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Literal;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -40,8 +41,8 @@ use EasyRdf\Literal;
 /**
  * Class that represents an RDF Literal of datatype xsd:dateTime
  *
- * @package    EasyRdf
- * @link       http://www.w3.org/TR/xmlschema-2/#date
+ * @see       http://www.w3.org/TR/xmlschema-2/#date
+ *
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
@@ -54,14 +55,14 @@ class DateTime extends Date
      *
      * @see \DateTime
      *
-     * @param  mixed  $value     The value of the literal
-     * @param  string $lang      Should be null (literals with a datatype can't have a language)
-     * @param  string $datatype  Optional datatype (default 'xsd:dateTime')
+     * @param mixed  $value    The value of the literal
+     * @param string $lang     Should be null (literals with a datatype can't have a language)
+     * @param string $datatype Optional datatype (default 'xsd:dateTime')
      */
     public function __construct($value = null, $lang = null, $datatype = null)
     {
         // If $value is null, use 'now'
-        if (is_null($value)) {
+        if (null === $value) {
             $value = new \DateTime('now');
         }
 
@@ -80,6 +81,7 @@ class DateTime extends Date
      *   $dt = EasyRdf\Literal\DateTime::parse('Mon 18 Jul 2011 18:45:43 BST');
      *
      * @see DateTime
+     *
      * @param string $value The date and time to parse
      *
      * @return self
@@ -87,33 +89,34 @@ class DateTime extends Date
     public static function parse($value)
     {
         $value = new \DateTime($value);
+
         return new self($value);
     }
 
     /** 24-hour format of the hour as an integer
      *
-     * @return integer
+     * @return int
      */
     public function hour()
     {
-        return (int)$this->format('H');
+        return (int) $this->format('H');
     }
 
     /** The minutes pasts the hour as an integer
      *
-     * @return integer
+     * @return int
      */
     public function min()
     {
-        return (int)$this->format('i');
+        return (int) $this->format('i');
     }
 
     /** The seconds pasts the minute as an integer
      *
-     * @return integer
+     * @return int
      */
     public function sec()
     {
-        return (int)$this->format('s');
+        return (int) $this->format('s');
     }
 }

--- a/lib/Literal/Decimal.php
+++ b/lib/Literal/Decimal.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Literal;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -40,8 +41,8 @@ use EasyRdf\Literal;
 /**
  * Class that represents an RDF Literal of datatype xsd:decimal
  *
- * @package    EasyRdf
- * @link       http://www.w3.org/TR/xmlschema-2/#decimal
+ * @see       http://www.w3.org/TR/xmlschema-2/#decimal
+ *
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
@@ -54,19 +55,19 @@ class Decimal extends Literal
 
     /** Constructor for creating a new decimal literal
      *
-     * @param  double|int|string $value    The value of the literal
-     * @param  string            $lang     Should be null (literals with a datatype can't have a language)
-     * @param  string            $datatype Optional datatype (default 'xsd:decimal')
+     * @param float|int|string $value    The value of the literal
+     * @param string           $lang     Should be null (literals with a datatype can't have a language)
+     * @param string           $datatype Optional datatype (default 'xsd:decimal')
      *
      * @throws \UnexpectedValueException
      */
     public function __construct($value, $lang = null, $datatype = null)
     {
-        if (is_string($value)) {
+        if (\is_string($value)) {
             self::validate($value);
-        } elseif (is_double($value) or is_int($value)) {
+        } elseif (\is_float($value) or \is_int($value)) {
             $locale_data = localeconv();
-            $value = str_replace($locale_data['decimal_point'], '.', strval($value));
+            $value = str_replace($locale_data['decimal_point'], '.', (string) $value);
         } else {
             throw new \UnexpectedValueException('EasyRdf\Literal\Decimal expects int/float/string as value');
         }
@@ -82,7 +83,7 @@ class Decimal extends Literal
      */
     public function getValue()
     {
-        return strval($this->value);
+        return (string) ($this->value);
     }
 
     /**
@@ -107,11 +108,11 @@ class Decimal extends Literal
      */
     public static function canonicalise($value)
     {
-        $pieces = array();
+        $pieces = [];
         mb_ereg(self::DECIMAL_REGEX, $value, $pieces);
 
-        $sign       = $pieces[1] === '-' ? '-' : '';  // '+' is not allowed
-        $integer    = ltrim(($pieces[4] !== false) ? $pieces[4] : $pieces[7], '0');
+        $sign = '-' === $pieces[1] ? '-' : '';  // '+' is not allowed
+        $integer = ltrim((false !== $pieces[4]) ? $pieces[4] : $pieces[7], '0');
         $fractional = rtrim($pieces[5], '0');
 
         if (empty($integer)) {

--- a/lib/Literal/HTML.php
+++ b/lib/Literal/HTML.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Literal;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -40,8 +41,8 @@ use EasyRdf\Literal;
 /**
  * Class that represents an RDF Literal of datatype rdf:HTML
  *
- * @package    EasyRdf
- * @link       http://www.w3.org/TR/rdf11-concepts/#section-html
+ * @see       http://www.w3.org/TR/rdf11-concepts/#section-html
+ *
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
@@ -49,9 +50,9 @@ class HTML extends Literal
 {
     /** Constructor for creating a new rdf:HTML literal
      *
-     * @param  mixed  $value     The HTML fragment
-     * @param  string $lang      Should be null (literals with a datatype can't have a language)
-     * @param  string $datatype  Optional datatype (default 'rdf:HTML')
+     * @param mixed  $value    The HTML fragment
+     * @param string $lang     Should be null (literals with a datatype can't have a language)
+     * @param string $datatype Optional datatype (default 'rdf:HTML')
      */
     public function __construct($value, $lang = null, $datatype = null)
     {
@@ -60,8 +61,9 @@ class HTML extends Literal
 
     /** Strip the HTML tags from the literal
      *
-     * @link   http://php.net/manual/en/function.strip-tags.php
-     * @param  string $allowableTags  Optional allowed tag, not be be removed
+     * @see   http://php.net/manual/en/function.strip-tags.php
+     *
+     * @param string $allowableTags Optional allowed tag, not be be removed
      *
      * @return string The literal as plain text
      */

--- a/lib/Literal/HexBinary.php
+++ b/lib/Literal/HexBinary.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Literal;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -40,8 +41,8 @@ use EasyRdf\Literal;
 /**
  * Class that represents an RDF Literal of datatype xsd:hexBinary
  *
- * @package    EasyRdf
- * @link       http://www.w3.org/TR/xmlschema-2/#hexBinary
+ * @see       http://www.w3.org/TR/xmlschema-2/#hexBinary
+ *
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
@@ -49,9 +50,9 @@ class HexBinary extends Literal
 {
     /** Constructor for creating a new xsd:hexBinary literal
      *
-     * @param  mixed  $value     The value of the literal (already encoded as hexadecimal)
-     * @param  string $lang      Should be null (literals with a datatype can't have a language)
-     * @param  string $datatype  Optional datatype (default 'xsd:hexBinary')
+     * @param mixed  $value    The value of the literal (already encoded as hexadecimal)
+     * @param string $lang     Should be null (literals with a datatype can't have a language)
+     * @param string $datatype Optional datatype (default 'xsd:hexBinary')
      *
      * @throws \InvalidArgumentException
      */
@@ -63,9 +64,7 @@ class HexBinary extends Literal
 
         // Validate the data
         if (preg_match('/[^A-F0-9]/', $value)) {
-            throw new \InvalidArgumentException(
-                "Literal of type xsd:hexBinary contains non-hexadecimal characters"
-            );
+            throw new \InvalidArgumentException('Literal of type xsd:hexBinary contains non-hexadecimal characters');
         }
 
         parent::__construct(strtoupper($value), null, 'xsd:hexBinary');
@@ -73,13 +72,13 @@ class HexBinary extends Literal
 
     /** Constructor for creating a new literal object from a binary blob
      *
-     * @param  string $binary  The binary data
+     * @param string $binary The binary data
      *
      * @return self
      */
     public static function fromBinary($binary)
     {
-        return new self( bin2hex($binary) );
+        return new self(bin2hex($binary));
     }
 
     /** Decode the hexadecimal string into a binary blob
@@ -88,6 +87,6 @@ class HexBinary extends Literal
      */
     public function toBinary()
     {
-        return pack("H*", $this->value);
+        return pack('H*', $this->value);
     }
 }

--- a/lib/Literal/Integer.php
+++ b/lib/Literal/Integer.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Literal;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -40,8 +41,8 @@ use EasyRdf\Literal;
 /**
  * Class that represents an RDF Literal of datatype xsd:integer
  *
- * @package    EasyRdf
- * @link       http://www.w3.org/TR/xmlschema-2/#integer
+ * @see       http://www.w3.org/TR/xmlschema-2/#integer
+ *
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
@@ -49,9 +50,9 @@ class Integer extends Literal
 {
     /** Constructor for creating a new integer literal
      *
-     * @param  mixed  $value     The value of the literal
-     * @param  string $lang      Should be null (literals with a datatype can't have a language)
-     * @param  string $datatype  Optional datatype (default 'xsd:integer')
+     * @param mixed  $value    The value of the literal
+     * @param string $lang     Should be null (literals with a datatype can't have a language)
+     * @param string $datatype Optional datatype (default 'xsd:integer')
      */
     public function __construct($value, $lang = null, $datatype = null)
     {
@@ -64,6 +65,6 @@ class Integer extends Literal
      */
     public function getValue()
     {
-        return (int)$this->value;
+        return (int) $this->value;
     }
 }

--- a/lib/Literal/XML.php
+++ b/lib/Literal/XML.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Literal;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -40,8 +41,8 @@ use EasyRdf\Literal;
 /**
  * Class that represents an RDF Literal of datatype rdf:XMLLiteral
  *
- * @package    EasyRdf
- * @link       http://www.w3.org/TR/REC-rdf-syntax/#section-Syntax-XML-literals
+ * @see       http://www.w3.org/TR/REC-rdf-syntax/#section-Syntax-XML-literals
+ *
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
@@ -49,9 +50,9 @@ class XML extends Literal
 {
     /** Constructor for creating a new rdf:XMLLiteral literal
      *
-     * @param  mixed  $value     The XML fragment
-     * @param  string $lang      Should be null (literals with a datatype can't have a language)
-     * @param  string $datatype  Optional datatype (default 'rdf:XMLLiteral')
+     * @param mixed  $value    The XML fragment
+     * @param string $lang     Should be null (literals with a datatype can't have a language)
+     * @param string $datatype Optional datatype (default 'rdf:XMLLiteral')
      */
     public function __construct($value, $lang = null, $datatype = null)
     {
@@ -60,13 +61,15 @@ class XML extends Literal
 
     /** Parse the XML literal into a DOMDocument
      *
-     * @link   http://php.net/manual/en/domdocument.loadxml.php
+     * @see   http://php.net/manual/en/domdocument.loadxml.php
+     *
      * @return \DOMDocument
      */
     public function domParse()
     {
         $dom = new \DOMDocument();
         $dom->loadXML($this->value, LIBXML_PARSEHUGE);
+
         return $dom;
     }
 }

--- a/lib/ParsedUri.php
+++ b/lib/ParsedUri.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EasyRdf;
 
 /**
@@ -31,19 +32,17 @@ namespace EasyRdf;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
 
-
 /**
  * A RFC3986 compliant URI parser
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
- * @link       http://www.ietf.org/rfc/rfc3986.txt
+ *
+ * @see       http://www.ietf.org/rfc/rfc3986.txt
  */
 class ParsedUri
 {
@@ -64,11 +63,11 @@ class ParsedUri
      * associative array with the following keys:
      * scheme, authority, path, query, fragment
      *
-     * @param  mixed $uri  The URI as a string or an array
+     * @param mixed $uri The URI as a string or an array
      */
     public function __construct($uri = null)
     {
-        if (is_string($uri)) {
+        if (\is_string($uri)) {
             if (preg_match(self::URI_REGEX, $uri, $matches)) {
                 if (!empty($matches[1])) {
                     $this->scheme = isset($matches[2]) ? $matches[2] : '';
@@ -84,7 +83,7 @@ class ParsedUri
                     $this->fragment = isset($matches[9]) ? $matches[9] : '';
                 }
             }
-        } elseif (is_array($uri)) {
+        } elseif (\is_array($uri)) {
             $this->scheme = isset($uri['scheme']) ? $uri['scheme'] : null;
             $this->authority = isset($uri['authority']) ? $uri['authority'] : null;
             $this->path = isset($uri['path']) ? $uri['path'] : null;
@@ -93,21 +92,20 @@ class ParsedUri
         }
     }
 
-
     /** Returns true if this is an absolute (complete) URI
-     * @return boolean
+     * @return bool
      */
     public function isAbsolute()
     {
-        return $this->scheme !== null;
+        return null !== $this->scheme;
     }
 
     /** Returns true if this is an relative (partial) URI
-     * @return boolean
+     * @return bool
      */
     public function isRelative()
     {
-        return $this->scheme === null;
+        return null === $this->scheme;
     }
 
     /** Returns the scheme of the URI (e.g. http)
@@ -190,7 +188,6 @@ class ParsedUri
         $this->fragment = $fragment;
     }
 
-
     /**
      * Normalises the path of this URI if it has one.
      *
@@ -206,34 +203,34 @@ class ParsedUri
         }
 
         // Remove ./ from the start
-        if (substr($this->path, 0, 2) == './') {
+        if ('./' == substr($this->path, 0, 2)) {
             // Remove both characters
             $this->path = substr($this->path, 2);
         }
 
         // Remove /. from the end
-        if (substr($this->path, -2) == '/.') {
+        if ('/.' == substr($this->path, -2)) {
             // Remove only the last dot, not the slash!
             $this->path = substr($this->path, 0, -1);
         }
 
-        if (substr($this->path, -3) == '/..') {
+        if ('/..' == substr($this->path, -3)) {
             $this->path .= '/';
         }
 
         // Split the path into its segments
         $segments = explode('/', $this->path);
-        $newSegments = array();
+        $newSegments = [];
 
         // Remove all unnecessary '.' and '..' segments
         foreach ($segments as $segment) {
-            if ($segment == '..') {
+            if ('..' == $segment) {
                 // Remove the previous part of the path
-                $count = count($newSegments);
-                if ($count > 0 && $newSegments[$count-1]) {
+                $count = \count($newSegments);
+                if ($count > 0 && $newSegments[$count - 1]) {
                     array_pop($newSegments);
                 }
-            } elseif ($segment == '.') {
+            } elseif ('.' == $segment) {
                 // Ignore
                 continue;
             } else {
@@ -254,7 +251,7 @@ class ParsedUri
     public function resolve($relUri)
     {
         // If it is a string, then convert it to a parsed object
-        if (is_string($relUri)) {
+        if (\is_string($relUri)) {
             $relUri = new self($relUri);
         }
 
@@ -279,18 +276,18 @@ class ParsedUri
                         $target->query = $this->query;
                     }
                 } else {
-                    if (substr($relUri->path, 0, 1) == '/') {
+                    if ('/' == substr($relUri->path, 0, 1)) {
                         $target->path = $relUri->path;
                     } else {
                         $path = $this->path;
                         $lastSlash = strrpos($path, '/');
-                        if ($lastSlash !== false) {
+                        if (false !== $lastSlash) {
                             $path = substr($path, 0, $lastSlash + 1);
                         } else {
                             $path = '/';
                         }
 
-                        $target->path .= $path . $relUri->path;
+                        $target->path .= $path.$relUri->path;
                     }
                     $target->query = $relUri->query;
                 }
@@ -313,19 +310,20 @@ class ParsedUri
     public function toString()
     {
         $str = '';
-        if ($this->scheme !== null) {
-            $str .= $this->scheme . ':';
+        if (null !== $this->scheme) {
+            $str .= $this->scheme.':';
         }
-        if ($this->authority !== null) {
-            $str .= '//' . $this->authority;
+        if (null !== $this->authority) {
+            $str .= '//'.$this->authority;
         }
         $str .= $this->path;
-        if ($this->query !== null) {
-            $str .= '?' . $this->query;
+        if (null !== $this->query) {
+            $str .= '?'.$this->query;
         }
-        if ($this->fragment !== null) {
-            $str .= '#' . $this->fragment;
+        if (null !== $this->fragment) {
+            $str .= '#'.$this->fragment;
         }
+
         return $str;
     }
 

--- a/lib/Parser.php
+++ b/lib/Parser.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EasyRdf;
 
 /**
@@ -31,7 +32,6 @@ namespace EasyRdf;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
@@ -39,14 +39,13 @@ namespace EasyRdf;
 /**
  * Parent class for the EasyRdf parsers
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
 class Parser
 {
     /** Mapping from source to graph bnode identifiers */
-    private $bnodeMap = array();
+    private $bnodeMap = [];
 
     /** The current graph to insert triples into */
     /** @var Graph */
@@ -58,13 +57,13 @@ class Parser
     /** The base URI for the document currently being parsed */
     protected $baseUri = null;
 
-
     protected $tripleCount = 0;
 
     /**
      * Create a new, unique bnode identifier from a source identifier.
      * If the source identifier has previously been seen, the
      * same new bnode identifier is returned.
+     *
      * @ignore
      */
     protected function remapBnode($name)
@@ -72,52 +71,47 @@ class Parser
         if (!isset($this->bnodeMap[$name])) {
             $this->bnodeMap[$name] = $this->graph->newBNodeId();
         }
+
         return $this->bnodeMap[$name];
     }
 
     /**
      * Delete the bnode mapping - to be called at the start of a new parse
+     *
      * @ignore
      */
     protected function resetBnodeMap()
     {
-        $this->bnodeMap = array();
+        $this->bnodeMap = [];
     }
 
     /**
      * Check, cleanup parameters and prepare for parsing
+     *
      * @ignore
      */
     protected function checkParseParams($graph, $data, $format, $baseUri)
     {
-        if ($graph == null or !is_object($graph) or
+        if (null == $graph or !\is_object($graph) or
             !($graph instanceof Graph)) {
-            throw new \InvalidArgumentException(
-                '$graph should be an EasyRdf\Graph object and cannot be null'
-            );
+            throw new \InvalidArgumentException('$graph should be an EasyRdf\Graph object and cannot be null');
         } else {
             $this->graph = $graph;
         }
 
-        if ($format == null or $format == '') {
-            throw new \InvalidArgumentException(
-                "\$format cannot be null or empty"
-            );
-        } elseif (is_object($format) and $format instanceof Format) {
+        if (null == $format or '' == $format) {
+            throw new \InvalidArgumentException('$format cannot be null or empty');
+        } elseif (\is_object($format) and $format instanceof Format) {
             $this->format = $format = $format->getName();
-        } elseif (!is_string($format)) {
-            throw new \InvalidArgumentException(
-                '$format should be a string or an EasyRdf\Format object'
-            );
+        } elseif (!\is_string($format)) {
+            throw new \InvalidArgumentException('$format should be a string or an EasyRdf\Format object');
         } else {
             $this->format = $format;
         }
 
         if ($baseUri) {
-            if (!is_string($baseUri)) {
-                throw new \InvalidArgumentException(
-                    "\$baseUri should be a string"
-                );
+            if (!\is_string($baseUri)) {
+                throw new \InvalidArgumentException('$baseUri should be a string');
             } else {
                 $this->baseUri = new ParsedUri($baseUri);
             }
@@ -132,23 +126,24 @@ class Parser
 
     /**
      * Sub-classes must follow this protocol
+     *
      * @ignore
      */
     public function parse($graph, $data, $format, $baseUri)
     {
-        throw new Exception(
-            "This method should be overridden by sub-classes."
-        );
+        throw new Exception('This method should be overridden by sub-classes.');
     }
 
     /**
      * Add a triple to the current graph, and keep count of the number of triples
+     *
      * @ignore
      */
     protected function addTriple($resource, $property, $value)
     {
         $count = $this->graph->add($resource, $property, $value);
         $this->tripleCount += $count;
+
         return $count;
     }
 }

--- a/lib/Parser/Arc.php
+++ b/lib/Parser/Arc.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EasyRdf\Parser;
 
 /**
@@ -31,7 +32,6 @@ namespace EasyRdf\Parser;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
@@ -39,18 +39,17 @@ namespace EasyRdf\Parser;
 /**
  * Class to parse RDF using the ARC2 library.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
 class Arc extends RdfPhp
 {
-    private static $supportedTypes = array(
+    private static $supportedTypes = [
         'rdfxml' => 'RDFXML',
         'turtle' => 'Turtle',
         'ntriples' => 'Turtle',
         'rdfa' => 'SemHTML',
-    );
+    ];
 
     /**
      * Constructor
@@ -71,29 +70,27 @@ class Arc extends RdfPhp
      * @param string $baseUri the base URI of the data being parsed
      *
      * @throws \EasyRdf\Exception
-     * @return integer             The number of triples added to the graph
+     *
+     * @return int The number of triples added to the graph
      */
     public function parse($graph, $data, $format, $baseUri)
     {
         parent::checkParseParams($graph, $data, $format, $baseUri);
 
-        if (array_key_exists($format, self::$supportedTypes)) {
+        if (\array_key_exists($format, self::$supportedTypes)) {
             $className = self::$supportedTypes[$format];
         } else {
-            throw new \EasyRdf\Exception(
-                "EasyRdf\\Parser\\Arc does not support: {$format}"
-            );
+            throw new \EasyRdf\Exception("EasyRdf\\Parser\\Arc does not support: {$format}");
         }
 
         $parser = \ARC2::getParser($className);
         if ($parser) {
             $parser->parse($baseUri, $data);
             $rdfphp = $parser->getSimpleIndex(false);
+
             return parent::parse($graph, $rdfphp, 'php', $baseUri);
         } else {
-            throw new \EasyRdf\Exception(
-                "ARC2 failed to get a $className parser."
-            );
+            throw new \EasyRdf\Exception("ARC2 failed to get a $className parser.");
         }
     }
 }

--- a/lib/Parser/Exception.php
+++ b/lib/Parser/Exception.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EasyRdf\Parser;
 
 /**
@@ -31,7 +32,6 @@ namespace EasyRdf\Parser;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
@@ -41,7 +41,6 @@ namespace EasyRdf\Parser;
  *
  * All exceptions thrown by EasyRdf are an instance of this class.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
@@ -49,27 +48,27 @@ class Exception extends \EasyRdf\Exception
 {
     protected $parserLine;
     protected $parserColumn;
-    
+
     public function __construct($message, $line = null, $column = null)
     {
         $this->parserLine = $line;
         $this->parserColumn = $column;
 
-        if (!is_null($line)) {
+        if (null !== $line) {
             $message .= " on line $line";
-            if (!is_null($column)) {
+            if (null !== $column) {
                 $message .= ", column $column";
             }
         }
 
         parent::__construct($message);
     }
-    
+
     public function getParserLine()
     {
         return $this->parserLine;
     }
-    
+
     public function getParserColumn()
     {
         return $this->parserColumn;

--- a/lib/Parser/Json.php
+++ b/lib/Parser/Json.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Parser;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -43,7 +44,6 @@ use EasyRdf\Graph;
  * http://n2.talis.com/wiki/RDF_JSON_Specification
  * docs/appendix-a-rdf-formats-json.md
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
@@ -56,7 +56,7 @@ class Json extends RdfPhp
      */
     public function __construct()
     {
-        $this->jsonLastErrorExists = function_exists('json_last_error');
+        $this->jsonLastErrorExists = \function_exists('json_last_error');
     }
 
     /** Return the last JSON parser error as a string
@@ -72,20 +72,20 @@ class Json extends RdfPhp
                 case JSON_ERROR_NONE:
                     return null;
                 case JSON_ERROR_DEPTH:
-                    return "JSON Parse error: the maximum stack depth has been exceeded";
+                    return 'JSON Parse error: the maximum stack depth has been exceeded';
                 case JSON_ERROR_STATE_MISMATCH:
-                    return "JSON Parse error: invalid or malformed JSON";
+                    return 'JSON Parse error: invalid or malformed JSON';
                 case JSON_ERROR_CTRL_CHAR:
-                    return "JSON Parse error: control character error, possibly incorrectly encoded";
+                    return 'JSON Parse error: control character error, possibly incorrectly encoded';
                 case JSON_ERROR_SYNTAX:
-                    return "JSON Parse syntax error";
+                    return 'JSON Parse syntax error';
                 case JSON_ERROR_UTF8:
-                    return "JSON Parse error: malformed UTF-8 characters, possibly incorrectly encoded";
+                    return 'JSON Parse error: malformed UTF-8 characters, possibly incorrectly encoded';
                 default:
-                    return "JSON Parse error: unknown";
+                    return 'JSON Parse error: unknown';
             }
         } else {
-            return "JSON Parse error";
+            return 'JSON Parse error';
         }
     }
 
@@ -98,7 +98,7 @@ class Json extends RdfPhp
     protected function parseJsonTriples($data, $baseUri)
     {
         foreach ($data['triples'] as $triple) {
-            if ($triple['subject']['type'] == 'bnode') {
+            if ('bnode' == $triple['subject']['type']) {
                 $subject = $this->remapBnode($triple['subject']['value']);
             } else {
                 $subject = $triple['subject']['value'];
@@ -106,11 +106,11 @@ class Json extends RdfPhp
 
             $predicate = $triple['predicate']['value'];
 
-            if ($triple['object']['type'] == 'bnode') {
-                $object = array(
+            if ('bnode' == $triple['object']['type']) {
+                $object = [
                     'type' => 'bnode',
-                    'value' => $this->remapBnode($triple['object']['value'])
-                );
+                    'value' => $this->remapBnode($triple['object']['value']),
+                ];
             } else {
                 $object = $triple['object'];
             }
@@ -131,26 +131,23 @@ class Json extends RdfPhp
      *
      * @throws Exception
      * @throws \EasyRdf\Exception
-     * @return integer             The number of triples added to the graph
+     *
+     * @return int The number of triples added to the graph
      */
     public function parse($graph, $data, $format, $baseUri)
     {
         $this->checkParseParams($graph, $data, $format, $baseUri);
 
-        if ($format != 'json') {
-            throw new \EasyRdf\Exception(
-                "EasyRdf\\Parser\\Json does not support: {$format}"
-            );
+        if ('json' != $format) {
+            throw new \EasyRdf\Exception("EasyRdf\\Parser\\Json does not support: {$format}");
         }
 
-        $decoded = @json_decode(strval($data), true);
-        if ($decoded === null) {
-            throw new Exception(
-                $this->jsonLastErrorString()
-            );
+        $decoded = @json_decode((string) $data, true);
+        if (null === $decoded) {
+            throw new Exception($this->jsonLastErrorString());
         }
 
-        if (array_key_exists('triples', $decoded)) {
+        if (\array_key_exists('triples', $decoded)) {
             return $this->parseJsonTriples($decoded, $baseUri);
         } else {
             return parent::parse($graph, $decoded, 'php', $baseUri);

--- a/lib/Parser/JsonLd.php
+++ b/lib/Parser/JsonLd.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Parser;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -42,7 +43,6 @@ use ML\JsonLD as LD;
 /**
  * Class to parse JSON-LD to an EasyRdf\Graph
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2014 Markus Lanthaler
  * @author     Markus Lanthaler <mail@markus-lanthaler.com>
  * @license    http://www.opensource.org/licenses/bsd-license.php
@@ -63,20 +63,19 @@ class JsonLd extends Parser
      *
      * @throws Exception
      * @throws \EasyRdf\Exception
-     * @return integer             The number of triples added to the graph
+     *
+     * @return int The number of triples added to the graph
      */
     public function parse($graph, $data, $format, $baseUri)
     {
         parent::checkParseParams($graph, $data, $format, $baseUri);
 
-        if ($format != 'jsonld') {
-            throw new \EasyRdf\Exception(
-                "EasyRdf\\Parser\\JsonLd does not support {$format}"
-            );
+        if ('jsonld' != $format) {
+            throw new \EasyRdf\Exception("EasyRdf\\Parser\\JsonLd does not support {$format}");
         }
 
         try {
-            $quads = LD\JsonLD::toRdf($data, array('base' => $baseUri));
+            $quads = LD\JsonLD::toRdf($data, ['base' => $baseUri]);
         } catch (LD\Exception\JsonLdException $e) {
             throw new Exception($e->getMessage());
         }
@@ -95,22 +94,22 @@ class JsonLd extends Parser
             $predicate = (string) $quad->getProperty();
 
             if ($quad->getObject() instanceof \ML\IRI\IRI) {
-                $object = array(
+                $object = [
                     'type' => 'uri',
-                    'value' => (string) $quad->getObject()
-                );
+                    'value' => (string) $quad->getObject(),
+                ];
 
                 if ('_:' === substr($object['value'], 0, 2)) {
-                    $object = array(
+                    $object = [
                         'type' => 'bnode',
-                        'value' => $this->remapBnode($object['value'])
-                    );
+                        'value' => $this->remapBnode($object['value']),
+                    ];
                 }
             } else {
-                $object = array(
+                $object = [
                     'type' => 'literal',
-                    'value' => $quad->getObject()->getValue()
-                );
+                    'value' => $quad->getObject()->getValue(),
+                ];
 
                 if ($quad->getObject() instanceof LD\LanguageTaggedString) {
                     $object['lang'] = $quad->getObject()->getLanguage();

--- a/lib/Parser/Ntriples.php
+++ b/lib/Parser/Ntriples.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Parser;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -41,7 +42,6 @@ use EasyRdf\Parser;
 /**
  * A pure-php class to parse N-Triples with no dependencies.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
@@ -51,30 +51,30 @@ class Ntriples extends Parser
      * Decodes an encoded N-Triples string. Any \-escape sequences are substituted
      * with their decoded value.
      *
-     * @param  string $str An encoded N-Triples string.
+     * @param string $str an encoded N-Triples string
      *
-     * @return string The unencoded string.
+     * @return string the unencoded string
      **/
     protected function unescapeString($str)
     {
-        if (strpos($str, '\\') === false) {
+        if (false === strpos($str, '\\')) {
             return $str;
         }
 
-        $mappings = array(
-            't' => chr(0x09),
-            'b' => chr(0x08),
-            'n' => chr(0x0A),
-            'r' => chr(0x0D),
-            'f' => chr(0x0C),
-            '\"' => chr(0x22),
-            '\'' => chr(0x27)
-        );
+        $mappings = [
+            't' => \chr(0x09),
+            'b' => \chr(0x08),
+            'n' => \chr(0x0A),
+            'r' => \chr(0x0D),
+            'f' => \chr(0x0C),
+            '\"' => \chr(0x22),
+            '\'' => \chr(0x27),
+        ];
         foreach ($mappings as $in => $out) {
-            $str = preg_replace('/\x5c([' . $in . '])/', $out, $str);
+            $str = preg_replace('/\x5c(['.$in.'])/', $out, $str);
         }
 
-        if (stripos($str, '\u') === false) {
+        if (false === stripos($str, '\u')) {
             return $str;
         }
 
@@ -82,25 +82,26 @@ class Ntriples extends Parser
                preg_match('/\\\(u)([0-9A-F]{4})/', $str, $matches)) {
             $no = hexdec($matches[2]);
             if ($no < 128) {                // 0x80
-                $char = chr($no);
+                $char = \chr($no);
             } elseif ($no < 2048) {         // 0x800
-                $char = chr(($no >> 6) + 192) .
-                        chr(($no & 63) + 128);
+                $char = \chr(($no >> 6) + 192).
+                        \chr(($no & 63) + 128);
             } elseif ($no < 65536) {        // 0x10000
-                $char = chr(($no >> 12) + 224) .
-                        chr((($no >> 6) & 63) + 128) .
-                        chr(($no & 63) + 128);
+                $char = \chr(($no >> 12) + 224).
+                        \chr((($no >> 6) & 63) + 128).
+                        \chr(($no & 63) + 128);
             } elseif ($no < 2097152) {      // 0x200000
-                $char = chr(($no >> 18) + 240) .
-                        chr((($no >> 12) & 63) + 128) .
-                        chr((($no >> 6) & 63) + 128) .
-                        chr(($no & 63) + 128);
+                $char = \chr(($no >> 18) + 240).
+                        \chr((($no >> 12) & 63) + 128).
+                        \chr((($no >> 6) & 63) + 128).
+                        \chr(($no & 63) + 128);
             } else {
-                # FIXME: throw an exception instead?
+                // FIXME: throw an exception instead?
                 $char = '';
             }
-            $str = str_replace('\\' . $matches[1] . $matches[2], $char, $str);
+            $str = str_replace('\\'.$matches[1].$matches[2], $char, $str);
         }
+
         return $str;
     }
 
@@ -116,13 +117,11 @@ class Ntriples extends Parser
                 return $this->graph->newBNodeId();
             } else {
                 $nodeid = $this->unescapeString($matches[1]);
+
                 return $this->remapBnode($nodeid);
             }
         } else {
-            throw new Exception(
-                "Failed to parse subject: $sub",
-                $lineNum
-            );
+            throw new Exception("Failed to parse subject: $sub", $lineNum);
         }
     }
 
@@ -132,39 +131,37 @@ class Ntriples extends Parser
     protected function parseNtriplesObject($obj, $lineNum)
     {
         if (preg_match('/"(.+)"\^\^<([^<>]+)>/', $obj, $matches)) {
-            return array(
+            return [
                 'type' => 'literal',
                 'value' => $this->unescapeString($matches[1]),
-                'datatype' => $this->unescapeString($matches[2])
-            );
+                'datatype' => $this->unescapeString($matches[2]),
+            ];
         } elseif (preg_match('/"(.+)"@([\w\-]+)/', $obj, $matches)) {
-            return array(
+            return [
                 'type' => 'literal',
                 'value' => $this->unescapeString($matches[1]),
-                'lang' => $this->unescapeString($matches[2])
-            );
+                'lang' => $this->unescapeString($matches[2]),
+            ];
         } elseif (preg_match('/"(.*)"/', $obj, $matches)) {
-            return array('type' => 'literal', 'value' => $this->unescapeString($matches[1]));
+            return ['type' => 'literal', 'value' => $this->unescapeString($matches[1])];
         } elseif (preg_match('/<([^<>]+)>/', $obj, $matches)) {
-            return array('type' => 'uri', 'value' => $this->unescapeString($matches[1]));
+            return ['type' => 'uri', 'value' => $this->unescapeString($matches[1])];
         } elseif (preg_match('/_:([A-Za-z0-9]*)/', $obj, $matches)) {
             if (empty($matches[1])) {
-                return array(
+                return [
                     'type' => 'bnode',
-                    'value' => $this->graph->newBNodeId()
-                );
+                    'value' => $this->graph->newBNodeId(),
+                ];
             } else {
                 $nodeid = $this->unescapeString($matches[1]);
-                return array(
+
+                return [
                     'type' => 'bnode',
-                    'value' => $this->remapBnode($nodeid)
-                );
+                    'value' => $this->remapBnode($nodeid),
+                ];
             }
         } else {
-            throw new Exception(
-                "Failed to parse object: $obj",
-                $lineNum
-            );
+            throw new Exception("Failed to parse object: $obj", $lineNum);
         }
     }
 
@@ -178,23 +175,22 @@ class Ntriples extends Parser
      *
      * @throws Exception
      * @throws \EasyRdf\Exception
-     * @return integer             The number of triples added to the graph
+     *
+     * @return int The number of triples added to the graph
      */
     public function parse($graph, $data, $format, $baseUri)
     {
         parent::checkParseParams($graph, $data, $format, $baseUri);
 
-        if ($format != 'ntriples') {
-            throw new \EasyRdf\Exception(
-                "EasyRdf\\Parser\\Ntriples does not support: $format"
-            );
+        if ('ntriples' != $format) {
+            throw new \EasyRdf\Exception("EasyRdf\\Parser\\Ntriples does not support: $format");
         }
 
-        $lines = preg_split('/\x0D?\x0A/', strval($data));
+        $lines = preg_split('/\x0D?\x0A/', (string) $data);
         foreach ($lines as $index => $line) {
             $lineNum = $index + 1;
             if (preg_match('/^\s*#/', $line)) {
-                # Comment
+                // Comment
                 continue;
             } elseif (preg_match('/^\s*(.+?)\s+<([^<>]+?)>\s+(.+?)\s*\.\s*$/', $line, $matches)) {
                 $this->addTriple(
@@ -203,13 +199,10 @@ class Ntriples extends Parser
                     $this->parseNtriplesObject($matches[3], $lineNum)
                 );
             } elseif (preg_match('/^\s*$/', $line)) {
-                # Blank line
+                // Blank line
                 continue;
             } else {
-                throw new Exception(
-                    "Failed to parse statement",
-                    $lineNum
-                );
+                throw new Exception('Failed to parse statement', $lineNum);
             }
         }
 

--- a/lib/Parser/Rapper.php
+++ b/lib/Parser/Rapper.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Parser;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -41,7 +42,6 @@ use EasyRdf\Utils;
 /**
  * Class to parse RDF using the 'rapper' command line tool.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
@@ -54,36 +54,32 @@ class Rapper extends Json
     /**
      * Constructor
      *
-     * @param string $rapperCmd Optional path to the rapper command to use.
+     * @param string $rapperCmd optional path to the rapper command to use
      *
      * @throws \EasyRdf\Exception
      */
     public function __construct($rapperCmd = 'rapper')
     {
         $result = exec("$rapperCmd --version 2>/dev/null", $output, $status);
-        if ($status != 0) {
-            throw new \EasyRdf\Exception(
-                "Failed to execute the command '$rapperCmd': $result"
-            );
+        if (0 != $status) {
+            throw new \EasyRdf\Exception("Failed to execute the command '$rapperCmd': $result");
         } elseif (version_compare($result, self::MINIMUM_RAPPER_VERSION) < 0) {
-            throw new \EasyRdf\Exception(
-                "Version ".self::MINIMUM_RAPPER_VERSION." or higher of rapper is required."
-            );
+            throw new \EasyRdf\Exception('Version '.self::MINIMUM_RAPPER_VERSION.' or higher of rapper is required.');
         } else {
             $this->rapperCmd = $rapperCmd;
         }
     }
 
     /**
-      * Parse an RDF document into an EasyRdf\Graph
-      *
-      * @param Graph  $graph   the graph to load the data into
-      * @param string $data    the RDF document data
-      * @param string $format  the format of the input data
-      * @param string $baseUri the base URI of the data being parsed
-      *
-      * @return integer             The number of triples added to the graph
-      */
+     * Parse an RDF document into an EasyRdf\Graph
+     *
+     * @param Graph  $graph   the graph to load the data into
+     * @param string $data    the RDF document data
+     * @param string $format  the format of the input data
+     * @param string $baseUri the base URI of the data being parsed
+     *
+     * @return int The number of triples added to the graph
+     */
     public function parse($graph, $data, $format, $baseUri)
     {
         parent::checkParseParams($graph, $data, $format, $baseUri);
@@ -94,14 +90,14 @@ class Rapper extends Json
 
         $json = Utils::execCommandPipe(
             $this->rapperCmd,
-            array(
+            [
                 '--quiet',
                 '--input', $format,
                 '--output', 'json',
                 '--ignore-errors',
                 '--input-uri', $baseUri,
-                '--output-uri', '-', '-'
-            ),
+                '--output-uri', '-', '-',
+            ],
             $data
         );
 

--- a/lib/Parser/RdfPhp.php
+++ b/lib/Parser/RdfPhp.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Parser;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -44,7 +45,6 @@ use EasyRdf\Parser;
  * http://n2.talis.com/wiki/RDF_PHP_Specification
  * docs/appendix-a-rdf-formats-php.md
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
@@ -60,69 +60,62 @@ class RdfPhp extends Parser
     /**
      * Parse RDF/PHP into an EasyRdf\Graph
      *
-     * @param Graph  $graph   the graph to load the data into
-     * @param array[] $data   the RDF document data
-     * @param string $format  the format of the input data
-     * @param string $baseUri the base URI of the data being parsed
+     * @param Graph   $graph   the graph to load the data into
+     * @param array[] $data    the RDF document data
+     * @param string  $format  the format of the input data
+     * @param string  $baseUri the base URI of the data being parsed
      *
      * @throws \EasyRdf\Exception
-     * @return integer        The number of triples added to the graph
+     *
+     * @return int The number of triples added to the graph
      */
     public function parse($graph, $data, $format, $baseUri)
     {
         $this->checkParseParams($graph, $data, $format, $baseUri);
 
-        if ($format != 'php') {
-            throw new \EasyRdf\Exception(
-                "EasyRdf\\Parser\\RdfPhp does not support: $format"
-            );
+        if ('php' != $format) {
+            throw new \EasyRdf\Exception("EasyRdf\\Parser\\RdfPhp does not support: $format");
         }
 
-        if (!is_array($data)) {
-            throw new Exception('expected array, got '.gettype($data));
+        if (!\is_array($data)) {
+            throw new Exception('expected array, got '.\gettype($data));
         }
 
         foreach ($data as $orig_subject => $properties) {
-            if (is_int($orig_subject)) {
+            if (\is_int($orig_subject)) {
                 throw new Exception('expected array indexed by IRIs, got list');
             }
 
-            if (substr($orig_subject, 0, 2) === '_:') {
+            if ('_:' === substr($orig_subject, 0, 2)) {
                 $subject = $this->remapBnode($orig_subject);
             } elseif (preg_match('/^\w+$/', $orig_subject)) {
-                # Cope with invalid RDF/JSON serialisations that
-                # put the node name in, without the _: prefix
-                # (such as net.fortytwo.sesametools.rdfjson)
+                // Cope with invalid RDF/JSON serialisations that
+                // put the node name in, without the _: prefix
+                // (such as net.fortytwo.sesametools.rdfjson)
                 $subject = $this->remapBnode($orig_subject);
             } else {
                 $subject = $orig_subject;
             }
 
-            if (!is_array($properties)) {
-                throw new Exception("expected array as value of '{$orig_subject}' key, got ".gettype($properties));
+            if (!\is_array($properties)) {
+                throw new Exception("expected array as value of '{$orig_subject}' key, got ".\gettype($properties));
             }
 
             foreach ($properties as $property => $objects) {
-                if (is_int($property)) {
+                if (\is_int($property)) {
                     throw new Exception("expected 'array indexed by IRIs' as value of '{$orig_subject}' key, got list");
                 }
 
-                if (!is_array($objects)) {
-                    throw new Exception(
-                        "expected list of objects as value of '{$orig_subject}' -> '{$property}' node, got ".
-                        gettype($objects)
-                    );
+                if (!\is_array($objects)) {
+                    throw new Exception("expected list of objects as value of '{$orig_subject}' -> '{$property}' node, got ".\gettype($objects));
                 }
 
                 foreach ($objects as $i => $object) {
-                    if (!is_array($object) or !isset($object['type']) or !isset($object['value'])) {
-                        throw new Exception(
-                            "expected array with 'type' and 'value' keys as value of ".
-                            "'{$orig_subject}' -> '{$property}' -> '{$i}' node"
-                        );
+                    if (!\is_array($object) or !isset($object['type']) or !isset($object['value'])) {
+                        throw new Exception("expected array with 'type' and 'value' keys as value of "."'{$orig_subject}' -> '{$property}' -> '{$i}' node");
                     }
 
-                    if ($object['type'] === 'bnode') {
+                    if ('bnode' === $object['type']) {
                         $object['value'] = $this->remapBnode($object['value']);
                     }
                     $this->addTriple($subject, $property, $object);

--- a/lib/RdfNamespace.php
+++ b/lib/RdfNamespace.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EasyRdf;
 
 /**
@@ -31,7 +32,6 @@ namespace EasyRdf;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2014 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
@@ -39,7 +39,6 @@ namespace EasyRdf;
 /**
  * A namespace registry and manipulation class.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2014 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
@@ -51,53 +50,52 @@ class RdfNamespace
      *  - http://www.w3.org/2011/rdfa-context/rdfa-1.1
      *
      * With a few extras added.
-     *
      */
-    private static $initial_namespaces = array(
-        'bibo'    => 'http://purl.org/ontology/bibo/',
-        'cc'      => 'http://creativecommons.org/ns#',
-        'cert'    => 'http://www.w3.org/ns/auth/cert#',
-        'ctag'    => 'http://commontag.org/ns#',
-        'dc'      => 'http://purl.org/dc/terms/',
-        'dc11'    => 'http://purl.org/dc/elements/1.1/',
-        'dcat'    => 'http://www.w3.org/ns/dcat#',
+    private static $initial_namespaces = [
+        'bibo' => 'http://purl.org/ontology/bibo/',
+        'cc' => 'http://creativecommons.org/ns#',
+        'cert' => 'http://www.w3.org/ns/auth/cert#',
+        'ctag' => 'http://commontag.org/ns#',
+        'dc' => 'http://purl.org/dc/terms/',
+        'dc11' => 'http://purl.org/dc/elements/1.1/',
+        'dcat' => 'http://www.w3.org/ns/dcat#',
         'dcterms' => 'http://purl.org/dc/terms/',
-        'doap'    => 'http://usefulinc.com/ns/doap#',
-        'exif'    => 'http://www.w3.org/2003/12/exif/ns#',
-        'foaf'    => 'http://xmlns.com/foaf/0.1/',
-        'geo'     => 'http://www.w3.org/2003/01/geo/wgs84_pos#',
-        'gr'      => 'http://purl.org/goodrelations/v1#',
-        'grddl'   => 'http://www.w3.org/2003/g/data-view#',
-        'ical'    => 'http://www.w3.org/2002/12/cal/icaltzd#',
-        'ma'      => 'http://www.w3.org/ns/ma-ont#',
-        'og'      => 'http://ogp.me/ns#',
-        'org'     => 'http://www.w3.org/ns/org#',
-        'owl'     => 'http://www.w3.org/2002/07/owl#',
-        'prov'    => 'http://www.w3.org/ns/prov#',
-        'qb'      => 'http://purl.org/linked-data/cube#',
-        'rdf'     => 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
-        'rdfa'    => 'http://www.w3.org/ns/rdfa#',
-        'rdfs'    => 'http://www.w3.org/2000/01/rdf-schema#',
-        'rev'     => 'http://purl.org/stuff/rev#',
-        'rif'     => 'http://www.w3.org/2007/rif#',
-        'rr'      => 'http://www.w3.org/ns/r2rml#',
-        'rss'     => 'http://purl.org/rss/1.0/',
-        'schema'  => 'http://schema.org/',
-        'sd'      => 'http://www.w3.org/ns/sparql-service-description#',
-        'sioc'    => 'http://rdfs.org/sioc/ns#',
-        'skos'    => 'http://www.w3.org/2004/02/skos/core#',
-        'skosxl'  => 'http://www.w3.org/2008/05/skos-xl#',
-        'synd'    => 'http://purl.org/rss/1.0/modules/syndication/',
-        'v'       => 'http://rdf.data-vocabulary.org/#',
-        'vcard'   => 'http://www.w3.org/2006/vcard/ns#',
-        'void'    => 'http://rdfs.org/ns/void#',
-        'wdr'     => 'http://www.w3.org/2007/05/powder#',
-        'wdrs'    => 'http://www.w3.org/2007/05/powder-s#',
-        'wot'     => 'http://xmlns.com/wot/0.1/',
-        'xhv'     => 'http://www.w3.org/1999/xhtml/vocab#',
-        'xml'     => 'http://www.w3.org/XML/1998/namespace',
-        'xsd'     => 'http://www.w3.org/2001/XMLSchema#',
-    );
+        'doap' => 'http://usefulinc.com/ns/doap#',
+        'exif' => 'http://www.w3.org/2003/12/exif/ns#',
+        'foaf' => 'http://xmlns.com/foaf/0.1/',
+        'geo' => 'http://www.w3.org/2003/01/geo/wgs84_pos#',
+        'gr' => 'http://purl.org/goodrelations/v1#',
+        'grddl' => 'http://www.w3.org/2003/g/data-view#',
+        'ical' => 'http://www.w3.org/2002/12/cal/icaltzd#',
+        'ma' => 'http://www.w3.org/ns/ma-ont#',
+        'og' => 'http://ogp.me/ns#',
+        'org' => 'http://www.w3.org/ns/org#',
+        'owl' => 'http://www.w3.org/2002/07/owl#',
+        'prov' => 'http://www.w3.org/ns/prov#',
+        'qb' => 'http://purl.org/linked-data/cube#',
+        'rdf' => 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
+        'rdfa' => 'http://www.w3.org/ns/rdfa#',
+        'rdfs' => 'http://www.w3.org/2000/01/rdf-schema#',
+        'rev' => 'http://purl.org/stuff/rev#',
+        'rif' => 'http://www.w3.org/2007/rif#',
+        'rr' => 'http://www.w3.org/ns/r2rml#',
+        'rss' => 'http://purl.org/rss/1.0/',
+        'schema' => 'http://schema.org/',
+        'sd' => 'http://www.w3.org/ns/sparql-service-description#',
+        'sioc' => 'http://rdfs.org/sioc/ns#',
+        'skos' => 'http://www.w3.org/2004/02/skos/core#',
+        'skosxl' => 'http://www.w3.org/2008/05/skos-xl#',
+        'synd' => 'http://purl.org/rss/1.0/modules/syndication/',
+        'v' => 'http://rdf.data-vocabulary.org/#',
+        'vcard' => 'http://www.w3.org/2006/vcard/ns#',
+        'void' => 'http://rdfs.org/ns/void#',
+        'wdr' => 'http://www.w3.org/2007/05/powder#',
+        'wdrs' => 'http://www.w3.org/2007/05/powder-s#',
+        'wot' => 'http://xmlns.com/wot/0.1/',
+        'xhv' => 'http://www.w3.org/1999/xhtml/vocab#',
+        'xml' => 'http://www.w3.org/XML/1998/namespace',
+        'xsd' => 'http://www.w3.org/2001/XMLSchema#',
+    ];
 
     private static $namespaces = null;
 
@@ -107,13 +105,13 @@ class RdfNamespace
     private static $anonymousNamespaceCount = 0;
 
     /**
-      * Return all the namespaces registered
-      *
-      * @return array Associative array of all the namespaces.
-      */
+     * Return all the namespaces registered
+     *
+     * @return array associative array of all the namespaces
+     */
     public static function namespaces()
     {
-        if (self::$namespaces === null) {
+        if (null === self::$namespaces) {
             self::resetNamespaces();
         }
 
@@ -130,31 +128,28 @@ class RdfNamespace
     }
 
     /**
-      * Return a namespace given its prefix.
-      *
-      * @param string $prefix The namespace prefix (eg 'foaf')
-      *
-      * @throws \InvalidArgumentException
-      * @return string The namespace URI (eg 'http://xmlns.com/foaf/0.1/')
-      */
+     * Return a namespace given its prefix.
+     *
+     * @param string $prefix The namespace prefix (eg 'foaf')
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return string The namespace URI (eg 'http://xmlns.com/foaf/0.1/')
+     */
     public static function get($prefix)
     {
-        if (!is_string($prefix) or $prefix === null) {
-            throw new \InvalidArgumentException(
-                "\$prefix should be a string and cannot be null or empty"
-            );
+        if (!\is_string($prefix) or null === $prefix) {
+            throw new \InvalidArgumentException('$prefix should be a string and cannot be null or empty');
         }
 
         if (preg_match('/\W/', $prefix)) {
-            throw new \InvalidArgumentException(
-                "\$prefix should only contain alpha-numeric characters"
-            );
+            throw new \InvalidArgumentException('$prefix should only contain alpha-numeric characters');
         }
 
         $prefix = strtolower($prefix);
         $namespaces = self::namespaces();
 
-        if (array_key_exists($prefix, $namespaces)) {
+        if (\array_key_exists($prefix, $namespaces)) {
             return $namespaces[$prefix];
         } else {
             return null;
@@ -162,23 +157,21 @@ class RdfNamespace
     }
 
     /**
-      * Register a new namespace.
-      *
-      * @param string $prefix The namespace prefix (eg 'foaf')
-      * @param string $long The namespace URI (eg 'http://xmlns.com/foaf/0.1/')
-      *
-      * @throws \LogicException
-      * @throws \InvalidArgumentException
-      */
+     * Register a new namespace.
+     *
+     * @param string $prefix The namespace prefix (eg 'foaf')
+     * @param string $long   The namespace URI (eg 'http://xmlns.com/foaf/0.1/')
+     *
+     * @throws \LogicException
+     * @throws \InvalidArgumentException
+     */
     public static function set($prefix, $long)
     {
-        if (!is_string($prefix) or $prefix === null) {
-            throw new \InvalidArgumentException(
-                "\$prefix should be a string and cannot be null or empty"
-            );
+        if (!\is_string($prefix) or null === $prefix) {
+            throw new \InvalidArgumentException('$prefix should be a string and cannot be null or empty');
         }
 
-        if ($prefix !== '') {
+        if ('' !== $prefix) {
             // prefix        ::= Name minus ":"                   // see: http://www.w3.org/TR/REC-xml-names/#NT-NCName
             // Name          ::= NameStartChar (NameChar)*        // see: http://www.w3.org/TR/REC-xml/#NT-Name
             // NameStartChar ::= ":" | [A-Z] | "_" | [a-z] | [#xC0-#xD6] | [#xD8-#xF6] | [#xF8-#x2FF] | [#x370-#x37D] |
@@ -187,33 +180,29 @@ class RdfNamespace
             // NameChar      ::= NameStartChar | "-" | "." | [0-9] | #xB7 | [#x0300-#x036F] | [#x203F-#x2040]
 
             $_name_start_char =
-                'A-Z_a-z\xc0-\xD6\xd8-\xf6\xf8-\xff\x{0100}-\x{02ff}\x{0370}-\x{037d}' .
-                '\x{037F}-\x{1FFF}\x{200C}-\x{200D}\x{2070}-\x{218F}\x{2C00}-\x{2FEF}\x{3001}-\x{D7FF}' .
+                'A-Z_a-z\xc0-\xD6\xd8-\xf6\xf8-\xff\x{0100}-\x{02ff}\x{0370}-\x{037d}'.
+                '\x{037F}-\x{1FFF}\x{200C}-\x{200D}\x{2070}-\x{218F}\x{2C00}-\x{2FEF}\x{3001}-\x{D7FF}'.
                 '\x{F900}-\x{FDCF}\x{FDF0}-\x{FFFD}\x{10000}-\x{EFFFF}';
 
             $_name_char =
-                $_name_start_char .
+                $_name_start_char.
                 '\-.0-9\xb7\x{0300}-\x{036f}\x{203f}-\x{2040}';
 
             $regex = "#^[{$_name_start_char}]{1}[{$_name_char}]{0,}$#u";
 
             $match_result = preg_match($regex, $prefix);
 
-            if ($match_result === false) {
+            if (false === $match_result) {
                 throw new \LogicException('regexp error');
             }
 
-            if ($match_result === 0) {
-                throw new \InvalidArgumentException(
-                    "\$prefix should match RDFXML-QName specification. got: {$prefix}"
-                );
+            if (0 === $match_result) {
+                throw new \InvalidArgumentException("\$prefix should match RDFXML-QName specification. got: {$prefix}");
             }
         }
 
-        if (!is_string($long) or $long === null or $long === '') {
-            throw new \InvalidArgumentException(
-                "\$long should be a string and cannot be null or empty"
-            );
+        if (!\is_string($long) or null === $long or '' === $long) {
+            throw new \InvalidArgumentException('$long should be a string and cannot be null or empty');
         }
 
         $prefix = strtolower($prefix);
@@ -225,42 +214,40 @@ class RdfNamespace
     }
 
     /**
-      * Get the default namespace
-      *
-      * Returns the URI of the default namespace or null
-      * if no default namespace is defined.
-      *
-      * @return string The URI of the default namespace
-      */
+     * Get the default namespace
+     *
+     * Returns the URI of the default namespace or null
+     * if no default namespace is defined.
+     *
+     * @return string The URI of the default namespace
+     */
     public static function getDefault()
     {
         return self::$default;
     }
 
     /**
-      * Set the default namespace
-      *
-      * Set the default namespace to either a URI or the prefix of
-      * an already defined namespace.
-      *
-      * Example:
-      *   EasyRdf\RdfNamespace::setDefault('http://schema.org/');
-      *
-      * @param string $namespace The URI or prefix of a namespace (eg 'og')
-      *
-      * @throws \InvalidArgumentException
-      */
+     * Set the default namespace
+     *
+     * Set the default namespace to either a URI or the prefix of
+     * an already defined namespace.
+     *
+     * Example:
+     *   EasyRdf\RdfNamespace::setDefault('http://schema.org/');
+     *
+     * @param string $namespace The URI or prefix of a namespace (eg 'og')
+     *
+     * @throws \InvalidArgumentException
+     */
     public static function setDefault($namespace)
     {
-        if (is_null($namespace) or $namespace === '') {
+        if (null === $namespace or '' === $namespace) {
             self::$default = null;
         } elseif (preg_match('/^\w+$/', $namespace)) {
             $namespaces = self::namespaces();
 
             if (!isset($namespaces[$namespace])) {
-                throw new \InvalidArgumentException(
-                    "Unable to set default namespace to unknown prefix: $namespace"
-                );
+                throw new \InvalidArgumentException("Unable to set default namespace to unknown prefix: $namespace");
             }
 
             self::$default = $namespaces[$namespace];
@@ -270,18 +257,16 @@ class RdfNamespace
     }
 
     /**
-      * Delete an existing namespace.
-      *
-      * @param string $prefix The namespace prefix (eg 'foaf')
-      *
-      * @throws \InvalidArgumentException
-      */
+     * Delete an existing namespace.
+     *
+     * @param string $prefix The namespace prefix (eg 'foaf')
+     *
+     * @throws \InvalidArgumentException
+     */
     public static function delete($prefix)
     {
-        if (!is_string($prefix) or $prefix === null or $prefix === '') {
-            throw new \InvalidArgumentException(
-                "\$prefix should be a string and cannot be null or empty"
-            );
+        if (!\is_string($prefix) or null === $prefix or '' === $prefix) {
+            throw new \InvalidArgumentException('$prefix should be a string and cannot be null or empty');
         }
 
         $prefix = strtolower($prefix);
@@ -292,69 +277,67 @@ class RdfNamespace
     }
 
     /**
-      * Delete the anonymous namespaces and reset the counter to 0
-      */
+     * Delete the anonymous namespaces and reset the counter to 0
+     */
     public static function reset()
     {
         while (self::$anonymousNamespaceCount > 0) {
-            self::delete('ns'.(self::$anonymousNamespaceCount-1));
-            self::$anonymousNamespaceCount--;
+            self::delete('ns'.(self::$anonymousNamespaceCount - 1));
+            --self::$anonymousNamespaceCount;
         }
     }
 
     /**
-      * Try and breakup a URI into a prefix and local part
-      *
-      * If $createNamespace is true, and the URI isn't part of an existing
-      * namespace, then EasyRdf will attempt to create a new namespace and
-      * return the name of the new prefix (for example 'ns0', 'term').
-      *
-      * If it isn't possible to split the URI, then null will be returned.
-      *
-      * @param string  $uri The full URI (eg 'http://xmlns.com/foaf/0.1/name')
-      * @param bool    $createNamespace If true, a new namespace will be created
-      *
-      * @throws \InvalidArgumentException
-      * @return array  The split URI (eg 'foaf', 'name') or null
-      */
+     * Try and breakup a URI into a prefix and local part
+     *
+     * If $createNamespace is true, and the URI isn't part of an existing
+     * namespace, then EasyRdf will attempt to create a new namespace and
+     * return the name of the new prefix (for example 'ns0', 'term').
+     *
+     * If it isn't possible to split the URI, then null will be returned.
+     *
+     * @param string $uri             The full URI (eg 'http://xmlns.com/foaf/0.1/name')
+     * @param bool   $createNamespace If true, a new namespace will be created
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return array The split URI (eg 'foaf', 'name') or null
+     */
     public static function splitUri($uri, $createNamespace = false)
     {
-        if ($uri === null or $uri === '') {
-            throw new \InvalidArgumentException(
-                "\$uri cannot be null or empty"
-            );
+        if (null === $uri or '' === $uri) {
+            throw new \InvalidArgumentException('$uri cannot be null or empty');
         }
 
-        if (is_object($uri) and ($uri instanceof Resource)) {
+        if (\is_object($uri) and ($uri instanceof Resource)) {
             $uri = $uri->getUri();
-        } elseif (!is_string($uri)) {
-            throw new \InvalidArgumentException(
-                '$uri should be a string or EasyRdf\Resource'
-            );
+        } elseif (!\is_string($uri)) {
+            throw new \InvalidArgumentException('$uri should be a string or EasyRdf\Resource');
         }
 
         foreach (self::namespaces() as $prefix => $long) {
-            if (substr($uri, 0, strlen($long)) !== $long) {
+            if (substr($uri, 0, \strlen($long)) !== $long) {
                 continue;
             }
 
-            $local_part = substr($uri, strlen($long));
+            $local_part = substr($uri, \strlen($long));
 
-            if (strpos($local_part, '/') !== false) {
+            if (false !== strpos($local_part, '/')) {
                 // we can't have '/' in local part
                 continue;
             }
 
-            return array($prefix, $local_part);
+            return [$prefix, $local_part];
         }
 
         if ($createNamespace) {
             // Try and create a new namespace
-            # FIXME: check the valid characters for an XML element name
+            // FIXME: check the valid characters for an XML element name
             if (preg_match('/^(.+?)([\w\-]+)$/', $uri, $matches)) {
-                $prefix = "ns".(self::$anonymousNamespaceCount++);
+                $prefix = 'ns'.(self::$anonymousNamespaceCount++);
                 self::set($prefix, $matches[1]);
-                return array($prefix, $matches[2]);
+
+                return [$prefix, $matches[2]];
             }
         }
 
@@ -362,12 +345,12 @@ class RdfNamespace
     }
 
     /**
-      * Return the prefix namespace that a URI belongs to.
-      *
-      * @param string $uri A full URI (eg 'http://xmlns.com/foaf/0.1/name')
+     * Return the prefix namespace that a URI belongs to.
      *
-      * @return string The prefix namespace that it is a part of(eg 'foaf')
-      */
+     * @param string $uri A full URI (eg 'http://xmlns.com/foaf/0.1/name')
+     *
+     * @return string The prefix namespace that it is a part of(eg 'foaf')
+     */
     public static function prefixOfUri($uri)
     {
         if ($parts = self::splitUri($uri)) {
@@ -376,19 +359,19 @@ class RdfNamespace
     }
 
     /**
-      * Shorten a URI by substituting in the namespace prefix.
-      *
-      * If $createNamespace is true, and the URI isn't part of an existing
-      * namespace, then EasyRdf will attempt to create a new namespace and
-      * use that namespace to shorten the URI (for example ns0:term).
-      *
-      * If it isn't possible to shorten the URI, then null will be returned.
-      *
-      * @param string  $uri The full URI (eg 'http://xmlns.com/foaf/0.1/name')
-      * @param bool    $createNamespace If true, a new namespace will be created
-      *
-      * @return string The shortened URI (eg 'foaf:name') or null
-      */
+     * Shorten a URI by substituting in the namespace prefix.
+     *
+     * If $createNamespace is true, and the URI isn't part of an existing
+     * namespace, then EasyRdf will attempt to create a new namespace and
+     * use that namespace to shorten the URI (for example ns0:term).
+     *
+     * If it isn't possible to shorten the URI, then null will be returned.
+     *
+     * @param string $uri             The full URI (eg 'http://xmlns.com/foaf/0.1/name')
+     * @param bool   $createNamespace If true, a new namespace will be created
+     *
+     * @return string The shortened URI (eg 'foaf:name') or null
+     */
     public static function shorten($uri, $createNamespace = false)
     {
         if ($parts = self::splitUri($uri, $createNamespace)) {
@@ -397,34 +380,34 @@ class RdfNamespace
     }
 
     /**
-      * Expand a shortened URI (qname) back into a full URI.
-      *
-      * If it isn't possible to expand the qname, for example if the namespace
-      * isn't registered, then the original string will be returned.
-      *
-      * @param string $shortUri The short URI (eg 'foaf:name')
-      *
-      * @throws \InvalidArgumentException
-      * @return string The full URI (eg 'http://xmlns.com/foaf/0.1/name')
-      */
+     * Expand a shortened URI (qname) back into a full URI.
+     *
+     * If it isn't possible to expand the qname, for example if the namespace
+     * isn't registered, then the original string will be returned.
+     *
+     * @param string $shortUri The short URI (eg 'foaf:name')
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return string The full URI (eg 'http://xmlns.com/foaf/0.1/name')
+     */
     public static function expand($shortUri)
     {
-        if (!is_string($shortUri) or $shortUri === '') {
-            throw new \InvalidArgumentException(
-                "\$shortUri should be a string and cannot be null or empty"
-            );
+        if (!\is_string($shortUri) or '' === $shortUri) {
+            throw new \InvalidArgumentException('$shortUri should be a string and cannot be null or empty');
         }
 
-        if ($shortUri === 'a') {
+        if ('a' === $shortUri) {
             $namespaces = self::namespaces();
-            return $namespaces['rdf'] . 'type';
+
+            return $namespaces['rdf'].'type';
         } elseif (preg_match('/^(\w+?):([\w\-]+)$/', $shortUri, $matches)) {
             $long = self::get($matches[1]);
             if ($long) {
-                return $long . $matches[2];
+                return $long.$matches[2];
             }
         } elseif (preg_match('/^(\w+)$/', $shortUri) and isset(self::$default)) {
-            return self::$default . $shortUri;
+            return self::$default.$shortUri;
         }
 
         return $shortUri;

--- a/lib/Resource.php
+++ b/lib/Resource.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EasyRdf;
 
 /**
@@ -31,7 +32,6 @@ namespace EasyRdf;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
@@ -39,7 +39,6 @@ namespace EasyRdf;
 /**
  * Class that represents an RDF resource
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
@@ -51,32 +50,26 @@ class Resource implements \ArrayAccess
     /** The Graph that this resource belongs to */
     protected $graph = null;
 
-
     /** Constructor
      *
      * * Please do not call new EasyRdf\Resource() directly *
      *
      * To create a new resource use the get method in a graph:
      * $resource = $graph->resource('http://www.example.com/');
-     *
      */
     public function __construct($uri, $graph = null)
     {
-        if (!is_string($uri) or $uri == null or $uri == '') {
-            throw new \InvalidArgumentException(
-                "\$uri should be a string and cannot be null or empty"
-            );
+        if (!\is_string($uri) or null == $uri or '' == $uri) {
+            throw new \InvalidArgumentException('$uri should be a string and cannot be null or empty');
         }
 
         $this->uri = $uri;
 
         // Check that $graph is an EasyRdf\Graph object
-        if (is_object($graph) and $graph instanceof Graph) {
+        if (\is_object($graph) and $graph instanceof Graph) {
             $this->graph = $graph;
-        } elseif (!is_null($graph)) {
-            throw new \InvalidArgumentException(
-                '$graph should be an EasyRdf\Graph object'
-            );
+        } elseif (null !== $graph) {
+            throw new \InvalidArgumentException('$graph should be an EasyRdf\Graph object');
         }
     }
 
@@ -92,7 +85,7 @@ class Resource implements \ArrayAccess
 
     /** Returns the URI for the resource.
      *
-     * @return string  URI of this resource.
+     * @return string URI of this resource
      */
     public function getUri()
     {
@@ -101,11 +94,11 @@ class Resource implements \ArrayAccess
 
     /** Check to see if a resource is a blank node.
      *
-     * @return bool True if this resource is a blank node.
+     * @return bool true if this resource is a blank node
      */
     public function isBNode()
     {
-        if (substr($this->uri, 0, 2) == '_:') {
+        if ('_:' == substr($this->uri, 0, 2)) {
             return true;
         } else {
             return false;
@@ -120,7 +113,7 @@ class Resource implements \ArrayAccess
      */
     public function getBNodeId()
     {
-        if (substr($this->uri, 0, 2) == '_:') {
+        if ('_:' == substr($this->uri, 0, 2)) {
             return substr($this->uri, 2);
         } else {
             return null;
@@ -160,7 +153,7 @@ class Resource implements \ArrayAccess
      */
     public function localName()
     {
-        if (preg_match("|([^#:/]+)$|", $this->uri, $matches)) {
+        if (preg_match('|([^#:/]+)$|', $this->uri, $matches)) {
             return $matches[1];
         }
     }
@@ -178,31 +171,30 @@ class Resource implements \ArrayAccess
      *
      * If no text is given, then the URI also uses as the link text.
      *
-     * @param  string  $text    Text for the link.
-     * @param  array   $options Associative array of attributes for the anchor tag
+     * @param string $text    text for the link
+     * @param array  $options Associative array of attributes for the anchor tag
      *
      * @throws \InvalidArgumentException
-     * @return string  The HTML link string
+     *
+     * @return string The HTML link string
      */
-    public function htmlLink($text = null, $options = array())
+    public function htmlLink($text = null, $options = [])
     {
-        $options = array_merge(array('href' => $this->uri), $options);
-        if ($text === null) {
+        $options = array_merge(['href' => $this->uri], $options);
+        if (null === $text) {
             $text = $this->uri;
         }
 
-        $html = "<a";
+        $html = '<a';
         foreach ($options as $key => $value) {
             if (!preg_match('/^[-\w]+$/', $key)) {
-                throw new \InvalidArgumentException(
-                    "\$options should use valid attribute names as keys"
-                );
+                throw new \InvalidArgumentException('$options should use valid attribute names as keys');
             }
 
-            $html .= " ".htmlspecialchars($key)."=\"".
-                         htmlspecialchars($value)."\"";
+            $html .= ' '.htmlspecialchars($key).'="'.
+                         htmlspecialchars($value).'"';
         }
-        $html .= ">".htmlspecialchars($text)."</a>";
+        $html .= '>'.htmlspecialchars($text).'</a>';
 
         return $html;
     }
@@ -212,21 +204,21 @@ class Resource implements \ArrayAccess
      * For example:
      * array('type' => 'uri', 'value' => 'http://www.example.com/')
      *
-     * @return array  The properties of the resource
+     * @return array The properties of the resource
      */
     public function toRdfPhp()
     {
         if ($this->isBNode()) {
-            return array('type' => 'bnode', 'value' => $this->uri);
+            return ['type' => 'bnode', 'value' => $this->uri];
         } else {
-            return array('type' => 'uri', 'value' => $this->uri);
+            return ['type' => 'uri', 'value' => $this->uri];
         }
     }
 
     /** Return pretty-print view of the resource
      *
-     * @param  string $format Either 'html' or 'text'
-     * @param  string $color The colour of the text
+     * @param string $format Either 'html' or 'text'
+     * @param string $color  The colour of the text
      *
      * @return string
      */
@@ -244,17 +236,13 @@ class Resource implements \ArrayAccess
         return $this->uri;
     }
 
-
-
     /** Throw can exception if the resource does not belong to a graph
      *  @ignore
      */
     protected function checkHasGraph()
     {
         if (!$this->graph) {
-            throw new Exception(
-                'EasyRdf\Resource is not part of a graph.'
-            );
+            throw new Exception('EasyRdf\Resource is not part of a graph.');
         }
     }
 
@@ -263,26 +251,28 @@ class Resource implements \ArrayAccess
      * The document type is optional but should be specified if it
      * can't be guessed or got from the HTTP headers.
      *
-     * @param  string  $format  Optional format of the data (eg. rdfxml)
+     * @param string $format Optional format of the data (eg. rdfxml)
      *
-     * @return integer
+     * @return int
      */
     public function load($format = null)
     {
         $this->checkHasGraph();
+
         return $this->graph->load($this->uri, $format);
     }
 
     /** Delete a property (or optionally just a specific value)
      *
-     * @param  string  $property The name of the property (e.g. foaf:name)
-     * @param  object  $value The value to delete (null to delete all values)
+     * @param string $property The name of the property (e.g. foaf:name)
+     * @param object $value    The value to delete (null to delete all values)
      *
-     * @return integer
+     * @return int
      */
     public function delete($property, $value = null)
     {
         $this->checkHasGraph();
+
         return $this->graph->delete($this->uri, $property, $value);
     }
 
@@ -291,14 +281,15 @@ class Resource implements \ArrayAccess
      * Example:
      *   $resource->add('prefix:property', 'value');
      *
-     * @param  mixed $property   The property name
-     * @param  mixed $value      The value for the property
+     * @param mixed $property The property name
+     * @param mixed $value    The value for the property
      *
-     * @return integer           The number of values added (1 or 0)
+     * @return int The number of values added (1 or 0)
      */
     public function add($property, $value)
     {
         $this->checkHasGraph();
+
         return $this->graph->add($this->uri, $property, $value);
     }
 
@@ -309,15 +300,16 @@ class Resource implements \ArrayAccess
      * Example:
      *   $resource->add('dc:title', 'Title of Page');
      *
-     * @param  mixed  $property  The property name
-     * @param  mixed  $values    The value or values for the property
-     * @param  string $lang      The language of the literal
+     * @param mixed  $property The property name
+     * @param mixed  $values   The value or values for the property
+     * @param string $lang     The language of the literal
      *
-     * @return integer           The number of values added
+     * @return int The number of values added
      */
     public function addLiteral($property, $values, $lang = null)
     {
         $this->checkHasGraph();
+
         return $this->graph->addLiteral($this->uri, $property, $values, $lang);
     }
 
@@ -326,14 +318,15 @@ class Resource implements \ArrayAccess
      * Example:
      *   $bob->add('foaf:knows', 'http://example.com/alice');
      *
-     * @param  mixed $property   The property name
-     * @param  mixed $resource2  The resource to be the value of the property
+     * @param mixed $property  The property name
+     * @param mixed $resource2 The resource to be the value of the property
      *
-     * @return integer           The number of values added (1 or 0)
+     * @return int The number of values added (1 or 0)
      */
     public function addResource($property, $resource2)
     {
         $this->checkHasGraph();
+
         return $this->graph->addResource($this->uri, $property, $resource2);
     }
 
@@ -344,14 +337,15 @@ class Resource implements \ArrayAccess
      * If you set a property to null or an empty array, then the property
      * will be deleted.
      *
-     * @param  string  $property The name of the property (e.g. foaf:name)
-     * @param  mixed   $value    The value for the property.
+     * @param string $property The name of the property (e.g. foaf:name)
+     * @param mixed  $value    the value for the property
      *
-     * @return integer           The number of values added (1 or 0)
+     * @return int The number of values added (1 or 0)
      */
     public function set($property, $value)
     {
         $this->checkHasGraph();
+
         return $this->graph->set($this->uri, $property, $value);
     }
 
@@ -365,15 +359,16 @@ class Resource implements \ArrayAccess
      *
      * This method will return null if the property does not exist.
      *
-     * @param  string|array $property The name of the property (e.g. foaf:name)
-     * @param  string       $type     The type of value to filter by (e.g. literal or resource)
-     * @param  string       $lang     The language to filter by (e.g. en)
+     * @param string|array $property The name of the property (e.g. foaf:name)
+     * @param string       $type     The type of value to filter by (e.g. literal or resource)
+     * @param string       $lang     The language to filter by (e.g. en)
      *
-     * @return mixed                  A value associated with the property
+     * @return mixed A value associated with the property
      */
     public function get($property, $type = null, $lang = null)
     {
         $this->checkHasGraph();
+
         return $this->graph->get($this->uri, $property, $type, $lang);
     }
 
@@ -385,14 +380,15 @@ class Resource implements \ArrayAccess
      * This method will return null if there is not literal value for the
      * property.
      *
-     * @param  string|array $property The name of the property (e.g. foaf:name)
-     * @param  string       $lang     The language to filter by (e.g. en)
+     * @param string|array $property The name of the property (e.g. foaf:name)
+     * @param string       $lang     The language to filter by (e.g. en)
      *
-     * @return Literal  Literal value associated with the property
+     * @return Literal Literal value associated with the property
      */
     public function getLiteral($property, $lang = null)
     {
         $this->checkHasGraph();
+
         return $this->graph->get($this->uri, $property, 'literal', $lang);
     }
 
@@ -404,13 +400,14 @@ class Resource implements \ArrayAccess
      * This method will return null if there is not resource for the
      * property.
      *
-     * @param  string|array $property The name of the property (e.g. foaf:name)
+     * @param string|array $property The name of the property (e.g. foaf:name)
      *
-     * @return self  Resource associated with the property
+     * @return self Resource associated with the property
      */
     public function getResource($property)
     {
         $this->checkHasGraph();
+
         return $this->graph->get($this->uri, $property, 'resource');
     }
 
@@ -418,15 +415,16 @@ class Resource implements \ArrayAccess
      *
      * This method will return an empty array if the property does not exist.
      *
-     * @param  string  $property The name of the property (e.g. foaf:name)
-     * @param  string  $type     The type of value to filter by (e.g. literal)
-     * @param  string  $lang     The language to filter by (e.g. en)
+     * @param string $property The name of the property (e.g. foaf:name)
+     * @param string $type     The type of value to filter by (e.g. literal)
+     * @param string $lang     The language to filter by (e.g. en)
      *
-     * @return array             An array of values associated with the property
+     * @return array An array of values associated with the property
      */
     public function all($property, $type = null, $lang = null)
     {
         $this->checkHasGraph();
+
         return $this->graph->all($this->uri, $property, $type, $lang);
     }
 
@@ -435,14 +433,15 @@ class Resource implements \ArrayAccess
      * This method will return an empty array if the resource does not
      * has any literal values for that property.
      *
-     * @param  string  $property The name of the property (e.g. foaf:name)
-     * @param  string  $lang     The language to filter by (e.g. en)
+     * @param string $property The name of the property (e.g. foaf:name)
+     * @param string $lang     The language to filter by (e.g. en)
      *
-     * @return array             An array of values associated with the property
+     * @return array An array of values associated with the property
      */
     public function allLiterals($property, $lang = null)
     {
         $this->checkHasGraph();
+
         return $this->graph->all($this->uri, $property, 'literal', $lang);
     }
 
@@ -451,13 +450,14 @@ class Resource implements \ArrayAccess
      * This method will return an empty array if the resource does not
      * has any resources for that property.
      *
-     * @param  string  $property The name of the property (e.g. foaf:name)
+     * @param string $property The name of the property (e.g. foaf:name)
      *
-     * @return array             An array of values associated with the property
+     * @return array An array of values associated with the property
      */
     public function allResources($property)
     {
         $this->checkHasGraph();
+
         return $this->graph->all($this->uri, $property, 'resource');
     }
 
@@ -465,15 +465,16 @@ class Resource implements \ArrayAccess
      *
      * This method will return 0 if the property does not exist.
      *
-     * @param  string  $property The name of the property (e.g. foaf:name)
-     * @param  string  $type     The type of value to filter by (e.g. literal)
-     * @param  string  $lang     The language to filter by (e.g. en)
+     * @param string $property The name of the property (e.g. foaf:name)
+     * @param string $type     The type of value to filter by (e.g. literal)
+     * @param string $lang     The language to filter by (e.g. en)
      *
-     * @return integer           The number of values associated with the property
+     * @return int The number of values associated with the property
      */
     public function countValues($property, $type = null, $lang = null)
     {
         $this->checkHasGraph();
+
         return $this->graph->countValues($this->uri, $property, $type, $lang);
     }
 
@@ -482,15 +483,16 @@ class Resource implements \ArrayAccess
      * The default is to join the values together with a space character.
      * This method will return an empty string if the property does not exist.
      *
-     * @param  string  $property The name of the property (e.g. foaf:name)
-     * @param  string  $glue     The string to glue the values together with.
-     * @param  string  $lang     The language to filter by (e.g. en)
+     * @param string $property The name of the property (e.g. foaf:name)
+     * @param string $glue     the string to glue the values together with
+     * @param string $lang     The language to filter by (e.g. en)
      *
-     * @return string            Concatenation of all the values.
+     * @return string concatenation of all the values
      */
     public function join($property, $glue = ' ', $lang = null)
     {
         $this->checkHasGraph();
+
         return $this->graph->join($this->uri, $property, $glue, $lang);
     }
 
@@ -498,11 +500,12 @@ class Resource implements \ArrayAccess
      *
      * This method will return an empty array if the resource has no properties.
      *
-     * @return array            Array of full URIs
+     * @return array Array of full URIs
      */
     public function propertyUris()
     {
         $this->checkHasGraph();
+
         return $this->graph->propertyUris($this->uri);
     }
 
@@ -510,21 +513,23 @@ class Resource implements \ArrayAccess
      *
      * This method will return an empty array if the resource has no properties.
      *
-     * @return array            Array of shortened URIs
+     * @return array Array of shortened URIs
      */
     public function properties()
     {
         $this->checkHasGraph();
+
         return $this->graph->properties($this->uri);
     }
 
     /** Get a list of the full URIs for the properties that point to this resource.
      *
-     * @return array   Array of full property URIs
+     * @return array Array of full property URIs
      */
     public function reversePropertyUris()
     {
         $this->checkHasGraph();
+
         return $this->graph->reversePropertyUris($this->uri);
     }
 
@@ -534,14 +539,15 @@ class Resource implements \ArrayAccess
      * If the value parameter is given, then it will only return true
      * if the value also exists for that property.
      *
-     * @param  string  $property The name of the property (e.g. foaf:name)
-     * @param  mixed   $value    An optional value of the property
+     * @param string $property The name of the property (e.g. foaf:name)
+     * @param mixed  $value    An optional value of the property
      *
-     * @return bool              True if value the property exists.
+     * @return bool true if value the property exists
      */
     public function hasProperty($property, $value = null)
     {
         $this->checkHasGraph();
+
         return $this->graph->hasProperty($this->uri, $property, $value);
     }
 
@@ -555,6 +561,7 @@ class Resource implements \ArrayAccess
     public function types()
     {
         $this->checkHasGraph();
+
         return $this->graph->types($this->uri);
     }
 
@@ -570,6 +577,7 @@ class Resource implements \ArrayAccess
     public function type()
     {
         $this->checkHasGraph();
+
         return $this->graph->type($this->uri);
     }
 
@@ -580,47 +588,52 @@ class Resource implements \ArrayAccess
      * may be arbitrary.
      * This method will return null if the resource has no type.
      *
-     * @return Resource A type assocated with the resource.
+     * @return resource a type assocated with the resource
      */
     public function typeAsResource()
     {
         $this->checkHasGraph();
+
         return $this->graph->typeAsResource($this->uri);
     }
 
     /**
      * Get a list of types for a resource, as EasyRdf\Resource
      *
-     * @return Resource[]
+     * @return resource[]
+     *
      * @throws Exception
      */
     public function typesAsResources()
     {
         $this->checkHasGraph();
+
         return $this->graph->typesAsResources($this->uri);
     }
 
     /** Check if a resource is of the specified type
      *
-     * @param  string  $type The type to check (e.g. foaf:Person)
+     * @param string $type The type to check (e.g. foaf:Person)
      *
-     * @return boolean       True if resource is of specified type.
+     * @return bool true if resource is of specified type
      */
     public function isA($type)
     {
         $this->checkHasGraph();
+
         return $this->graph->isA($this->uri, $type);
     }
 
     /** Add one or more rdf:type properties to the resource
      *
-     * @param  string  $types    One or more types to add (e.g. foaf:Person)
+     * @param string $types One or more types to add (e.g. foaf:Person)
      *
-     * @return integer           The number of types added
+     * @return int The number of types added
      */
     public function addType($types)
     {
         $this->checkHasGraph();
+
         return $this->graph->addType($this->uri, $types);
     }
 
@@ -628,13 +641,14 @@ class Resource implements \ArrayAccess
      *
      * Note that the PHP class of the resource will not change.
      *
-     * @param  string  $type     The new type (e.g. foaf:Person)
+     * @param string $type The new type (e.g. foaf:Person)
      *
-     * @return integer           The number of types added
+     * @return int The number of types added
      */
     public function setType($type)
     {
         $this->checkHasGraph();
+
         return $this->graph->setType($this->uri, $type);
     }
 
@@ -642,11 +656,12 @@ class Resource implements \ArrayAccess
      *
      * Returns null if no primary topic is available.
      *
-     * @return Resource The primary topic of this resource.
+     * @return resource the primary topic of this resource
      */
     public function primaryTopic()
     {
         $this->checkHasGraph();
+
         return $this->graph->primaryTopic($this->uri);
     }
 
@@ -659,11 +674,12 @@ class Resource implements \ArrayAccess
      *
      * @param string|null $lang
      *
-     * @return string A label for the resource.
+     * @return string a label for the resource
      */
     public function label($lang = null)
     {
         $this->checkHasGraph();
+
         return $this->graph->label($this->uri, $lang);
     }
 
@@ -672,13 +688,14 @@ class Resource implements \ArrayAccess
      * This method is intended to be a debugging aid and will
      * print a resource and its properties.
      *
-     * @param  string $format   Either 'html' or 'text'
+     * @param string $format Either 'html' or 'text'
      *
      * @return string
      */
     public function dump($format = 'html')
     {
         $this->checkHasGraph();
+
         return $this->graph->dumpResource($this->uri, $format);
     }
 
@@ -691,9 +708,9 @@ class Resource implements \ArrayAccess
      *
      * @see EasyRdf\RdfNamespace::setDefault()
      *
-     * @param  string $name  The name of the property
+     * @param string $name The name of the property
      *
-     * @return string  A single value for the named property
+     * @return string A single value for the named property
      */
     public function __get($name)
     {
@@ -709,8 +726,8 @@ class Resource implements \ArrayAccess
      *
      * @see EasyRdf\RdfNamespace::setDefault()
      *
-     * @param  string $name  The name of the property
-     * @param  string $value The value for the property
+     * @param string $name  The name of the property
+     * @param string $value The value for the property
      *
      * @return int
      */
@@ -763,11 +780,11 @@ class Resource implements \ArrayAccess
      * Example:
      *   if(isset($resource['rdfs:label'])) { }
      *
-     * @link http://php.net/manual/en/arrayaccess.offsetexists.php
+     * @see http://php.net/manual/en/arrayaccess.offsetexists.php
      *
-     * @param mixed $offset An offset to check for.
+     * @param mixed $offset an offset to check for
      *
-     * @return boolean true on success or false on failure.
+     * @return bool true on success or false on failure
      */
     public function offsetExists($offset)
     {
@@ -780,11 +797,11 @@ class Resource implements \ArrayAccess
      * Example:
      *   $label = $resource['rdfs:label'];
      *
-     * @link http://php.net/manual/en/arrayaccess.offsetget.php
+     * @see http://php.net/manual/en/arrayaccess.offsetget.php
      *
-     * @param mixed $offset The offset to retrieve.
+     * @param mixed $offset the offset to retrieve
      *
-     * @return mixed Can return all value types.
+     * @return mixed can return all value types
      */
     public function offsetGet($offset)
     {
@@ -797,10 +814,10 @@ class Resource implements \ArrayAccess
      * Example:
      *   $resource['rdfs:label'] = 'label';
      *
-     * @link http://php.net/manual/en/arrayaccess.offsetset.php
+     * @see http://php.net/manual/en/arrayaccess.offsetset.php
      *
-     * @param mixed The offset to assign the value to.
-     * @param mixed $value The value to set.
+     * @param mixed the offset to assign the value to
+     * @param mixed $value the value to set
      *
      * @return void
      */
@@ -815,9 +832,9 @@ class Resource implements \ArrayAccess
      * Example:
      *   unset($resource['rdfs:label']);
      *
-     * @link http://php.net/manual/en/arrayaccess.offsetunset.php
+     * @see http://php.net/manual/en/arrayaccess.offsetunset.php
      *
-     * @param mixed $offset  The offset to unset.
+     * @param mixed $offset the offset to unset
      *
      * @return void
      */

--- a/lib/Serialiser.php
+++ b/lib/Serialiser.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EasyRdf;
 
 /**
@@ -31,7 +32,6 @@ namespace EasyRdf;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
@@ -39,40 +39,37 @@ namespace EasyRdf;
 /**
  * Parent class for the EasyRdf serialiser
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
 abstract class Serialiser
 {
-    protected $prefixes = array();
+    protected $prefixes = [];
 
     /**
      * Keep track of the prefixes used while serialising
+     *
      * @ignore
      */
     protected function addPrefix($qname)
     {
-        list ($prefix) = explode(':', $qname);
+        list($prefix) = explode(':', $qname);
         $this->prefixes[$prefix] = true;
     }
 
     /**
      * Check and cleanup parameters passed to serialise() method
+     *
      * @ignore
      */
     protected function checkSerialiseParams(&$format)
     {
-        if (is_null($format) or $format == '') {
-            throw new \InvalidArgumentException(
-                '$format cannot be null or empty'
-            );
-        } elseif (is_object($format) and ($format instanceof Format)) {
+        if (null === $format or '' == $format) {
+            throw new \InvalidArgumentException('$format cannot be null or empty');
+        } elseif (\is_object($format) and ($format instanceof Format)) {
             $format = $format->getName();
-        } elseif (!is_string($format)) {
-            throw new \InvalidArgumentException(
-                '$format should be a string or an EasyRdf\Format object'
-            );
+        } elseif (!\is_string($format)) {
+            throw new \InvalidArgumentException('$format should be a string or an EasyRdf\Format object');
         }
     }
 
@@ -80,29 +77,29 @@ abstract class Serialiser
      * Protected method to get the number of reverse properties for a resource
      * If a resource only has a single property, the number of values for that
      * property is returned instead.
+     *
      * @ignore
      */
     protected function reversePropertyCount($resource)
     {
         $properties = $resource->reversePropertyUris();
-        $count = count($properties);
-        if ($count == 1) {
+        $count = \count($properties);
+        if (1 == $count) {
             $property = $properties[0];
+
             return $resource->countValues("^<$property>");
         } else {
             return $count;
         }
     }
 
-
     /**
      * Serialise an EasyRdf\Graph into desired format.
      *
-     * @param Graph         $graph  An EasyRdf\Graph object.
-     * @param Format|string $format The name of the format to convert to.
-     * @param array         $options
+     * @param Graph         $graph  an EasyRdf\Graph object
+     * @param Format|string $format the name of the format to convert to
      *
-     * @return string The RDF in the new desired format.
+     * @return string the RDF in the new desired format
      */
-    abstract public function serialise(Graph $graph, $format, array $options = array());
+    abstract public function serialise(Graph $graph, $format, array $options = []);
 }

--- a/lib/Serialiser/Arc.php
+++ b/lib/Serialiser/Arc.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Serialiser;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -42,18 +43,17 @@ use EasyRdf\Graph;
 /**
  * Class to serialise RDF using the ARC2 library.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
 class Arc extends RdfPhp
 {
-    private static $supportedTypes = array(
+    private static $supportedTypes = [
         'rdfxml' => 'RDFXML',
         'turtle' => 'Turtle',
         'ntriples' => 'NTriples',
-        'posh' => 'POSHRDF'
-    );
+        'posh' => 'POSHRDF',
+    ];
 
     /**
      * Constructor
@@ -65,27 +65,24 @@ class Arc extends RdfPhp
         }
     }
 
-
     /**
      * Serialise an EasyRdf\Graph into RDF format of choice.
      *
-     * @param Graph  $graph  An EasyRdf\Graph object.
-     * @param string $format The name of the format to convert to.
-     * @param array  $options
+     * @param Graph  $graph  an EasyRdf\Graph object
+     * @param string $format the name of the format to convert to
      *
-     * @return string The RDF in the new desired format.
+     * @return string the RDF in the new desired format
+     *
      * @throws Exception
      */
-    public function serialise(Graph $graph, $format, array $options = array())
+    public function serialise(Graph $graph, $format, array $options = [])
     {
         parent::checkSerialiseParams($format);
 
-        if (array_key_exists($format, self::$supportedTypes)) {
+        if (\array_key_exists($format, self::$supportedTypes)) {
             $className = self::$supportedTypes[$format];
         } else {
-            throw new Exception(
-                "EasyRdf\\Serialiser\\Arc does not support: {$format}"
-            );
+            throw new Exception("EasyRdf\\Serialiser\\Arc does not support: {$format}");
         }
 
         /** @var \ARC2_RDFSerializer $serialiser */
@@ -95,9 +92,7 @@ class Arc extends RdfPhp
                 parent::serialise($graph, 'php')
             );
         } else {
-            throw new Exception(
-                "ARC2 failed to get a $className serialiser."
-            );
+            throw new Exception("ARC2 failed to get a $className serialiser.");
         }
     }
 }

--- a/lib/Serialiser/GraphViz.php
+++ b/lib/Serialiser/GraphViz.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Serialiser;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -49,7 +50,6 @@ use EasyRdf\Utils;
  *
  * See http://www.graphviz.org/ for more information.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2012-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
@@ -58,20 +58,21 @@ class GraphViz extends Serialiser
     private $dotCommand = 'dot';
     private $useLabels = false;
     private $onlyLabelled = false;
-    private $attributes = array('charset' => 'utf-8');
+    private $attributes = ['charset' => 'utf-8'];
 
     /**
      * Set the path to the GraphViz 'dot' command
      *
      * Default is to search PATH for the command 'dot'.
      *
-     * @param string $cmd   The path to the 'dot' command.
+     * @param string $cmd the path to the 'dot' command
      *
      * @return self
      */
     public function setDotCommand($cmd)
     {
         $this->dotCommand = $cmd;
+
         return $this;
     }
 
@@ -80,7 +81,7 @@ class GraphViz extends Serialiser
      *
      * The default value is simply 'dot'
      *
-     * @return string The path to the 'dot' command.
+     * @return string the path to the 'dot' command
      */
     public function getDotCommand()
     {
@@ -97,13 +98,14 @@ class GraphViz extends Serialiser
      *
      * This option is turned off by default.
      *
-     * @param bool $useLabels   A boolean value to turn labels on and off
+     * @param bool $useLabels A boolean value to turn labels on and off
      *
      * @return GraphViz
      */
     public function setUseLabels($useLabels)
     {
         $this->useLabels = $useLabels;
+
         return $this;
     }
 
@@ -127,13 +129,14 @@ class GraphViz extends Serialiser
      *
      * This option is turned off by default.
      *
-     * @param bool $onlyLabelled   A boolean value to enable/display only labelled items
+     * @param bool $onlyLabelled A boolean value to enable/display only labelled items
      *
      * @return GraphViz
      */
     public function setOnlyLabelled($onlyLabelled)
     {
         $this->onlyLabelled = $onlyLabelled;
+
         return $this;
     }
 
@@ -156,21 +159,22 @@ class GraphViz extends Serialiser
      * See the GraphViz tool documentation for information about the
      * available attributes.
      *
-     * @param string $name    The name of the attribute
-     * @param string $value   The value for the attribute
+     * @param string $name  The name of the attribute
+     * @param string $value The value for the attribute
      *
      * @return GraphViz
      */
     public function setAttribute($name, $value)
     {
         $this->attributes[$name] = $value;
+
         return $this;
     }
 
     /**
      * Get an attribute of the GraphViz graph
      *
-     * @param string $name    Attribute name
+     * @param string $name Attribute name
      *
      * @return string The value of the graph attribute
      */
@@ -188,12 +192,12 @@ class GraphViz extends Serialiser
     {
         if ($entity instanceof Resource) {
             if ($entity->isBNode()) {
-                return "B".$entity->getUri();
+                return 'B'.$entity->getUri();
             } else {
-                return "R".$entity->getUri();
+                return 'R'.$entity->getUri();
             }
         } else {
-            return "L".$entity;
+            return 'L'.$entity;
         }
     }
 
@@ -208,8 +212,8 @@ class GraphViz extends Serialiser
             return $input;
         } else {
             return '"'.str_replace(
-                array("\r\n", "\n", "\r", '"'),
-                array('\n',   '\n', '\n', '\"'),
+                ["\r\n", "\n", "\r", '"'],
+                ['\n',   '\n', '\n', '\"'],
                 $input
             ).'"';
         }
@@ -223,10 +227,11 @@ class GraphViz extends Serialiser
      */
     protected function escapeAttributes($array)
     {
-        $items = array();
+        $items = [];
         foreach ($array as $k => $v) {
             $items[] = $this->escape($k).'='.$this->escape($v);
         }
+
         return '['.implode(',', $items).']';
     }
 
@@ -235,15 +240,16 @@ class GraphViz extends Serialiser
      *
      * @ignore
      */
-    protected function serialiseRow($node1, $node2 = null, $attributes = array())
+    protected function serialiseRow($node1, $node2 = null, $attributes = [])
     {
         $result = '  '.$this->escape($node1);
         if ($node2) {
             $result .= ' -> '.$this->escape($node2);
         }
-        if (count($attributes)) {
+        if (\count($attributes)) {
             $result .= ' '.$this->escapeAttributes($attributes);
         }
+
         return $result.";\n";
     }
 
@@ -262,7 +268,7 @@ class GraphViz extends Serialiser
         }
 
         // Go through each of the properties and write the edges
-        $nodes = array();
+        $nodes = [];
         $result .= "\n  // Edges\n";
         foreach ($graph->resources() as $resource) {
             $name1 = $this->nodeName($resource);
@@ -271,8 +277,8 @@ class GraphViz extends Serialiser
                 if ($this->useLabels) {
                     $label = $graph->resource($property)->label();
                 }
-                if ($label === null) {
-                    if ($this->onlyLabelled == true) {
+                if (null === $label) {
+                    if (true == $this->onlyLabelled) {
                         continue;
                     } else {
                         $label = RdfNamespace::shorten($property);
@@ -285,7 +291,7 @@ class GraphViz extends Serialiser
                     $result .= $this->serialiseRow(
                         $name1,
                         $name2,
-                        array('label' => $label)
+                        ['label' => $label]
                     );
                 }
             }
@@ -297,7 +303,7 @@ class GraphViz extends Serialiser
         foreach ($nodes as $name => $node) {
             $type = substr($name, 0, 1);
             $label = '';
-            if ($type == 'R') {
+            if ('R' == $type) {
                 if ($this->useLabels) {
                     $label = $node->label();
                 }
@@ -310,37 +316,36 @@ class GraphViz extends Serialiser
                 $result .= $this->serialiseRow(
                     $name,
                     null,
-                    array(
-                        'URL'   => $node->getURI(),
+                    [
+                        'URL' => $node->getURI(),
                         'label' => $label,
                         'shape' => 'ellipse',
-                        'color' => 'blue'
-                    )
+                        'color' => 'blue',
+                    ]
                 );
-            } elseif ($type == 'B') {
+            } elseif ('B' == $type) {
                 if ($this->useLabels) {
                     $label = $node->label();
                 }
                 $result .= $this->serialiseRow(
                     $name,
                     null,
-                    array(
+                    [
                         'label' => $label,
                         'shape' => 'circle',
-                        'color' => 'green'
-                    )
+                        'color' => 'green',
+                    ]
                 );
             } else {
                 $result .= $this->serialiseRow(
                     $name,
                     null,
-                    array(
-                        'label' => strval($node),
+                    [
+                        'label' => (string) $node,
                         'shape' => 'record',
-                    )
+                    ]
                 );
             }
-
         }
 
         $result .= "}\n";
@@ -359,29 +364,28 @@ class GraphViz extends Serialiser
 
         return Utils::execCommandPipe(
             $this->dotCommand,
-            array("-T$format"),
+            ["-T$format"],
             $dot
         );
     }
-
 
     /**
      * Serialise an EasyRdf\Graph into a GraphViz dot document.
      *
      * Supported output format names: dot, gif, png, svg
      *
-     * @param Graph  $graph  An EasyRdf\Graph object.
-     * @param string $format The name of the format to convert to.
-     * @param array  $options
+     * @param Graph  $graph  an EasyRdf\Graph object
+     * @param string $format the name of the format to convert to
      *
-     * @return string The RDF in the new desired format.
+     * @return string the RDF in the new desired format
+     *
      * @throws Exception
      */
-    public function serialise(Graph $graph, $format, array $options = array())
+    public function serialise(Graph $graph, $format, array $options = [])
     {
         parent::checkSerialiseParams($format);
 
-        switch($format) {
+        switch ($format) {
             case 'dot':
                 return $this->serialiseDot($graph);
             case 'png':
@@ -389,9 +393,7 @@ class GraphViz extends Serialiser
             case 'svg':
                 return $this->renderImage($graph, $format);
             default:
-                throw new Exception(
-                    "EasyRdf\\Serialiser\\GraphViz does not support: {$format}"
-                );
+                throw new Exception("EasyRdf\\Serialiser\\GraphViz does not support: {$format}");
         }
     }
 }

--- a/lib/Serialiser/Json.php
+++ b/lib/Serialiser/Json.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Serialiser;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -42,7 +43,6 @@ use EasyRdf\Graph;
  * Class to serialise an EasyRdf\Graph to RDF/JSON
  * with no external dependencies.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
@@ -54,21 +54,19 @@ class Json extends RdfPhp
      * http://n2.talis.com/wiki/RDF_JSON_Specification
      * docs/appendix-a-rdf-formats-json.md
      *
-     * @param Graph  $graph  An EasyRdf\Graph object.
-     * @param string $format The name of the format to convert to.
-     * @param array  $options
+     * @param Graph  $graph  an EasyRdf\Graph object
+     * @param string $format the name of the format to convert to
      *
-     * @return string The RDF in the new desired format.
+     * @return string the RDF in the new desired format
+     *
      * @throws Exception
      */
-    public function serialise(Graph $graph, $format, array $options = array())
+    public function serialise(Graph $graph, $format, array $options = [])
     {
         parent::checkSerialiseParams($format);
 
-        if ($format != 'json') {
-            throw new Exception(
-                "EasyRdf\\Serialiser\\Json does not support: {$format}"
-            );
+        if ('json' != $format) {
+            throw new Exception("EasyRdf\\Serialiser\\Json does not support: {$format}");
         }
 
         return json_encode(parent::serialise($graph, 'php'));

--- a/lib/Serialiser/JsonLd.php
+++ b/lib/Serialiser/JsonLd.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Serialiser;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -38,13 +39,11 @@ namespace EasyRdf\Serialiser;
 use EasyRdf\Exception;
 use EasyRdf\Graph;
 use EasyRdf\Serialiser;
-
 use ML\JsonLD as LD;
 
 /**
  * Class to serialise an EasyRdf\Graph to JSON-LD
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2013 Alexey Zakhlestin
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
@@ -57,31 +56,29 @@ class JsonLd extends Serialiser
         }
     }
 
-
     /**
      * Serialise an EasyRdf\Graph into a JSON-LD document.
      *
-     * @param Graph  $graph  An EasyRdf\Graph object.
-     * @param string $format The name of the format to convert to.
-     * @param array  $options
+     * @param Graph  $graph  an EasyRdf\Graph object
+     * @param string $format the name of the format to convert to
      *
-     * @return string The RDF in the new desired format.
+     * @return string the RDF in the new desired format
+     *
      * @throws Exception
      */
-    public function serialise(Graph $graph, $format, array $options = array())
+    public function serialise(Graph $graph, $format, array $options = [])
     {
         parent::checkSerialiseParams($format);
 
-        if ($format != 'jsonld') {
+        if ('jsonld' != $format) {
             throw new Exception(__CLASS__.' does not support: '.$format);
         }
 
-
         $ld_graph = new LD\Graph();
-        $nodes = array(); // cache for id-to-node association
+        $nodes = []; // cache for id-to-node association
 
         foreach ($graph->toRdfPhp() as $resource => $properties) {
-            if (array_key_exists($resource, $nodes)) {
+            if (\array_key_exists($resource, $nodes)) {
                 $node = $nodes[$resource];
             } else {
                 $node = $ld_graph->createNode($resource);
@@ -90,14 +87,14 @@ class JsonLd extends Serialiser
 
             foreach ($properties as $property => $values) {
                 foreach ($values as $value) {
-                    if ($value['type'] == 'bnode' or $value['type'] == 'uri') {
-                        if (array_key_exists($value['value'], $nodes)) {
+                    if ('bnode' == $value['type'] or 'uri' == $value['type']) {
+                        if (\array_key_exists($value['value'], $nodes)) {
                             $_value = $nodes[$value['value']];
                         } else {
                             $_value = $ld_graph->createNode($value['value']);
                             $nodes[$value['value']] = $_value;
                         }
-                    } elseif ($value['type'] == 'literal') {
+                    } elseif ('literal' == $value['type']) {
                         if (isset($value['lang'])) {
                             $_value = new LD\LanguageTaggedString($value['value'], $value['lang']);
                         } elseif (isset($value['datatype'])) {
@@ -106,12 +103,10 @@ class JsonLd extends Serialiser
                             $_value = $value['value'];
                         }
                     } else {
-                        throw new Exception(
-                            "Unable to serialise object to JSON-LD: ".$value['type']
-                        );
+                        throw new Exception('Unable to serialise object to JSON-LD: '.$value['type']);
                     }
 
-                    if ($property == "http://www.w3.org/1999/02/22-rdf-syntax-ns#type") {
+                    if ('http://www.w3.org/1999/02/22-rdf-syntax-ns#type' == $property) {
                         $node->addType($_value);
                     } else {
                         $node->addPropertyValue($property, $_value);
@@ -121,8 +116,8 @@ class JsonLd extends Serialiser
         }
 
         // OPTIONS
-        $use_native_types = !(isset($options['expand_native_types']) and $options['expand_native_types'] == true);
-        $should_compact = (isset($options['compact']) and $options['compact'] == true);
+        $use_native_types = !(isset($options['expand_native_types']) and true == $options['expand_native_types']);
+        $should_compact = (isset($options['compact']) and true == $options['compact']);
         $should_frame = isset($options['frame']);
 
         // expanded form
@@ -130,16 +125,15 @@ class JsonLd extends Serialiser
 
         if ($should_frame) {
             $data = LD\JsonLD::frame($data, $options['frame'], $options);
-
         }
 
         if ($should_compact) {
             // compact form
             $compact_context = isset($options['context']) ? $options['context'] : null;
-            $compact_options = array(
+            $compact_options = [
                 'useNativeTypes' => $use_native_types,
-                'base' => $graph->getUri()
-            );
+                'base' => $graph->getUri(),
+            ];
 
             $data = LD\JsonLD::compact($data, $compact_context, $compact_options);
         }

--- a/lib/Serialiser/Ntriples.php
+++ b/lib/Serialiser/Ntriples.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Serialiser;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -43,13 +44,12 @@ use EasyRdf\Serialiser;
  * Class to serialise an EasyRdf\Graph to N-Triples
  * with no external dependencies.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
 class Ntriples extends Serialiser
 {
-    private $escChars = array();   // Character encoding cache
+    private $escChars = [];   // Character encoding cache
 
     /**
      * @ignore
@@ -57,10 +57,10 @@ class Ntriples extends Serialiser
     protected function escapeString($str)
     {
         $result = '';
-        $strLen = mb_strlen($str, "UTF-8");
+        $strLen = mb_strlen($str, 'UTF-8');
 
-        for ($i = 0; $i < $strLen; $i++) {
-            $c = mb_substr($str, $i, 1, "UTF-8");
+        for ($i = 0; $i < $strLen; ++$i) {
+            $c = mb_substr($str, $i, 1, 'UTF-8');
 
             if (!isset($this->escChars[$c])) {
                 $this->escChars[$c] = $this->escapedChar($c);
@@ -77,28 +77,29 @@ class Ntriples extends Serialiser
      */
     protected function unicodeCharNo($cUtf)
     {
-        $bl = strlen($cUtf); /* binary length */
+        $bl = \strlen($cUtf); /* binary length */
         $r = 0;
         switch ($bl) {
             case 1: /* 0####### (0-127) */
-                $r = ord($cUtf);
+                $r = \ord($cUtf);
                 break;
             case 2: /* 110##### 10###### = 192+x 128+x */
-                $r = ((ord($cUtf[0]) - 192) * 64) +
-                     (ord($cUtf[1]) - 128);
+                $r = ((\ord($cUtf[0]) - 192) * 64) +
+                     (\ord($cUtf[1]) - 128);
                 break;
             case 3: /* 1110#### 10###### 10###### = 224+x 128+x 128+x */
-                $r = ((ord($cUtf[0]) - 224) * 4096) +
-                     ((ord($cUtf[1]) - 128) * 64) +
-                     (ord($cUtf[2]) - 128);
+                $r = ((\ord($cUtf[0]) - 224) * 4096) +
+                     ((\ord($cUtf[1]) - 128) * 64) +
+                     (\ord($cUtf[2]) - 128);
                 break;
             case 4: /* 1111#### 10###### 10###### 10###### = 240+x 128+x 128+x 128+x */
-                $r = ((ord($cUtf[0]) - 240) * 262144) +
-                     ((ord($cUtf[1]) - 128) * 4096) +
-                     ((ord($cUtf[2]) - 128) * 64) +
-                     (ord($cUtf[3]) - 128);
+                $r = ((\ord($cUtf[0]) - 240) * 262144) +
+                     ((\ord($cUtf[1]) - 128) * 4096) +
+                     ((\ord($cUtf[2]) - 128) * 64) +
+                     (\ord($cUtf[3]) - 128);
                 break;
         }
+
         return $r;
     }
 
@@ -111,31 +112,31 @@ class Ntriples extends Serialiser
 
         /* see http://www.w3.org/TR/rdf-testcases/#ntrip_strings */
         if ($no < 9) {
-            return "\\u" . sprintf('%04X', $no);  /* #x0-#x8 (0-8) */
-        } elseif ($no == 9) {
+            return '\\u'.sprintf('%04X', $no);  /* #x0-#x8 (0-8) */
+        } elseif (9 == $no) {
             return '\t';                          /* #x9 (9) */
-        } elseif ($no == 10) {
+        } elseif (10 == $no) {
             return '\n';                          /* #xA (10) */
         } elseif ($no < 13) {
-            return "\\u" . sprintf('%04X', $no);  /* #xB-#xC (11-12) */
-        } elseif ($no == 13) {
+            return '\\u'.sprintf('%04X', $no);  /* #xB-#xC (11-12) */
+        } elseif (13 == $no) {
             return '\r';                          /* #xD (13) */
         } elseif ($no < 32) {
-            return "\\u" . sprintf('%04X', $no);  /* #xE-#x1F (14-31) */
+            return '\\u'.sprintf('%04X', $no);  /* #xE-#x1F (14-31) */
         } elseif ($no < 34) {
             return $c;                            /* #x20-#x21 (32-33) */
-        } elseif ($no == 34) {
+        } elseif (34 == $no) {
             return '\"';                          /* #x22 (34) */
         } elseif ($no < 92) {
             return $c;                            /* #x23-#x5B (35-91) */
-        } elseif ($no == 92) {
+        } elseif (92 == $no) {
             return '\\\\'; // double backslash    /* #x5C (92) */
         } elseif ($no < 127) {
             return $c;                            /* #x5D-#x7E (93-126) */
         } elseif ($no < 65536) {
-            return "\\u" . sprintf('%04X', $no);  /* #x7F-#xFFFF (128-65535) */
+            return '\\u'.sprintf('%04X', $no);  /* #x7F-#xFFFF (128-65535) */
         } elseif ($no < 1114112) {
-            return "\\U" . sprintf('%08X', $no);  /* #x10000-#x10FFFF (65536-1114111) */
+            return '\\U'.sprintf('%08X', $no);  /* #x10000-#x10FFFF (65536-1114111) */
         } else {
             return '';                            /* not defined => ignore */
         }
@@ -147,7 +148,7 @@ class Ntriples extends Serialiser
     protected function serialiseResource($res)
     {
         $escaped = $this->escapeString($res);
-        if (substr($res, 0, 2) == '_:') {
+        if ('_:' == substr($res, 0, 2)) {
             return $escaped;
         } else {
             return "<$escaped>";
@@ -160,7 +161,7 @@ class Ntriples extends Serialiser
      * The value can either be an array in RDF/PHP form, or
      * an EasyRdf\Literal or EasyRdf\Resource object.
      *
-     * @param array|object  $value   An associative array or an object
+     * @param array|object $value An associative array or an object
      *
      * @throws Exception
      *
@@ -168,61 +169,59 @@ class Ntriples extends Serialiser
      */
     public function serialiseValue($value)
     {
-        if (is_object($value)) {
+        if (\is_object($value)) {
             $value = $value->toRdfPhp();
         }
 
-        if ($value['type'] == 'uri' or $value['type'] == 'bnode') {
+        if ('uri' == $value['type'] or 'bnode' == $value['type']) {
             return $this->serialiseResource($value['value']);
-        } elseif ($value['type'] == 'literal') {
+        } elseif ('literal' == $value['type']) {
             $escaped = $this->escapeString($value['value']);
             if (isset($value['lang'])) {
                 $lang = $this->escapeString($value['lang']);
-                return '"' . $escaped . '"' . '@' . $lang;
+
+                return '"'.$escaped.'"'.'@'.$lang;
             } elseif (isset($value['datatype'])) {
                 $datatype = $this->escapeString($value['datatype']);
-                return '"' . $escaped . '"' . "^^<$datatype>";
+
+                return '"'.$escaped.'"'."^^<$datatype>";
             } else {
-                return '"' . $escaped . '"';
+                return '"'.$escaped.'"';
             }
         } else {
-            throw new Exception(
-                "Unable to serialise object of type '".$value['type']."' to ntriples: "
-            );
+            throw new Exception("Unable to serialise object of type '".$value['type']."' to ntriples: ");
         }
     }
-
 
     /**
      * Serialise an EasyRdf\Graph into N-Triples
      *
-     * @param Graph  $graph  An EasyRdf\Graph object.
-     * @param string $format The name of the format to convert to.
-     * @param array  $options
+     * @param Graph  $graph  an EasyRdf\Graph object
+     * @param string $format the name of the format to convert to
      *
-     * @return string The RDF in the new desired format.
+     * @return string the RDF in the new desired format
+     *
      * @throws Exception
      */
-    public function serialise(Graph $graph, $format, array $options = array())
+    public function serialise(Graph $graph, $format, array $options = [])
     {
         parent::checkSerialiseParams($format);
 
-        if ($format == 'ntriples') {
+        if ('ntriples' == $format) {
             $nt = '';
             foreach ($graph->toRdfPhp() as $resource => $properties) {
                 foreach ($properties as $property => $values) {
                     foreach ($values as $value) {
-                        $nt .= $this->serialiseResource($resource)." ";
-                        $nt .= "<" . $this->escapeString($property) . "> ";
+                        $nt .= $this->serialiseResource($resource).' ';
+                        $nt .= '<'.$this->escapeString($property).'> ';
                         $nt .= $this->serialiseValue($value)." .\n";
                     }
                 }
             }
+
             return $nt;
         } else {
-            throw new Exception(
-                __CLASS__." does not support: $format"
-            );
+            throw new Exception(__CLASS__." does not support: $format");
         }
     }
 }

--- a/lib/Serialiser/Rapper.php
+++ b/lib/Serialiser/Rapper.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Serialiser;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -45,7 +46,6 @@ use EasyRdf\Utils;
  *
  * Note: the built-in N-Triples serialiser is used to pass data to Rapper.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
@@ -56,52 +56,49 @@ class Rapper extends Ntriples
     /**
      * Constructor
      *
-     * @param string $rapperCmd Optional path to the rapper command to use.
+     * @param string $rapperCmd optional path to the rapper command to use
      *
      * @throws \EasyRdf\Exception
      */
     public function __construct($rapperCmd = 'rapper')
     {
         $result = exec("$rapperCmd --version 2>/dev/null", $output, $status);
-        if ($status != 0) {
-            throw new Exception(
-                "Failed to execute the command '$rapperCmd': $result"
-            );
+        if (0 != $status) {
+            throw new Exception("Failed to execute the command '$rapperCmd': $result");
         } else {
             $this->rapperCmd = $rapperCmd;
         }
     }
 
-
     /**
      * Serialise an EasyRdf\Graph to the RDF format of choice.
      *
-     * @param \EasyRdf\Graph $graph  An EasyRdf\Graph object.
-     * @param string         $format The name of the format to convert to.
-     * @param array          $options
+     * @param \EasyRdf\Graph $graph  an EasyRdf\Graph object
+     * @param string         $format the name of the format to convert to
      *
-     * @return string The RDF in the new desired format.
+     * @return string the RDF in the new desired format
+     *
      * @throws Exception
      */
-    public function serialise(Graph $graph, $format, array $options = array())
+    public function serialise(Graph $graph, $format, array $options = [])
     {
         parent::checkSerialiseParams($format);
 
         $ntriples = parent::serialise($graph, 'ntriples');
 
         // Hack to produce more concise RDF/XML
-        if ($format == 'rdfxml') {
+        if ('rdfxml' == $format) {
             $format = 'rdfxml-abbrev';
         }
 
         return Utils::execCommandPipe(
             $this->rapperCmd,
-            array(
+            [
                 '--quiet',
                 '--input', 'ntriples',
                 '--output', $format,
-                '-', 'unknown://'
-            ),
+                '-', 'unknown://',
+            ],
             $ntriples
         );
     }

--- a/lib/Serialiser/RdfPhp.php
+++ b/lib/Serialiser/RdfPhp.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Serialiser;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -43,7 +44,6 @@ use EasyRdf\Serialiser;
  * Class to serialise an EasyRdf\Graph to RDF/PHP
  * with no external dependencies.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
@@ -55,21 +55,19 @@ class RdfPhp extends Serialiser
      * http://n2.talis.com/wiki/RDF_PHP_Specification
      * docs/appendix-a-rdf-formats-php.md
      *
-     * @param Graph  $graph  An EasyRdf\Graph object.
-     * @param string $format The name of the format to convert to.
-     * @param array  $options
+     * @param Graph  $graph  an EasyRdf\Graph object
+     * @param string $format the name of the format to convert to
      *
-     * @return string The RDF in the new desired format.
+     * @return string the RDF in the new desired format
+     *
      * @throws Exception
      */
-    public function serialise(Graph $graph, $format, array $options = array())
+    public function serialise(Graph $graph, $format, array $options = [])
     {
         parent::checkSerialiseParams($format);
 
-        if ($format != 'php') {
-            throw new Exception(
-                __CLASS__." does not support: $format"
-            );
+        if ('php' != $format) {
+            throw new Exception(__CLASS__." does not support: $format");
         }
 
         // Graph is already stored as RDF/PHP resource-centric array internally within the EasyRdf\Graph object

--- a/lib/Serialiser/RdfXml.php
+++ b/lib/Serialiser/RdfXml.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Serialiser;
 
-    /**
+    /*
  * EasyRdf
  *
  * LICENSE
@@ -47,47 +48,47 @@ use EasyRdf\Serialiser;
  * Class to serialise an EasyRdf\Graph to RDF/XML
  * with no external dependencies.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
 class RdfXml extends Serialiser
 {
-    private $outputtedResources = array();
+    private $outputtedResources = [];
 
     /** A constant for the RDF Type property URI */
     const RDF_XML_LITERAL = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral';
 
     /**
      * Protected method to serialise an object node into an XML object
+     *
      * @ignore
      */
     protected function rdfxmlObject($property, $obj, $depth)
     {
         $indent = str_repeat('  ', $depth);
 
-        if ($property[0] === ':') {
+        if (':' === $property[0]) {
             $property = substr($property, 1);
         }
 
-        if (is_object($obj) and $obj instanceof Resource) {
-            $pcount = count($obj->propertyUris());
+        if (\is_object($obj) and $obj instanceof Resource) {
+            $pcount = \count($obj->propertyUris());
             $rpcount = $this->reversePropertyCount($obj);
             $alreadyOutput = isset($this->outputtedResources[$obj->getUri()]);
 
             $tag = "{$indent}<{$property}";
             if ($obj->isBNode()) {
-                if ($alreadyOutput or $rpcount > 1 or $pcount == 0) {
-                    $tag .= " rdf:nodeID=\"".htmlspecialchars($obj->getBNodeId()).'"';
+                if ($alreadyOutput or $rpcount > 1 or 0 == $pcount) {
+                    $tag .= ' rdf:nodeID="'.htmlspecialchars($obj->getBNodeId()).'"';
                 }
             } else {
-                if ($alreadyOutput or $rpcount != 1 or $pcount == 0) {
-                    $tag .= " rdf:resource=\"".htmlspecialchars($obj->getURI()).'"';
+                if ($alreadyOutput or 1 != $rpcount or 0 == $pcount) {
+                    $tag .= ' rdf:resource="'.htmlspecialchars($obj->getURI()).'"';
                 }
             }
 
-            if ($alreadyOutput == false and $rpcount == 1 and $pcount > 0) {
-                $xml = $this->rdfxmlResource($obj, false, $depth+1);
+            if (false == $alreadyOutput and 1 == $rpcount and $pcount > 0) {
+                $xml = $this->rdfxmlResource($obj, false, $depth + 1);
                 if ($xml) {
                     return "$tag>$xml$indent</$property>\n\n";
                 } else {
@@ -96,14 +97,13 @@ class RdfXml extends Serialiser
             } else {
                 return $tag."/>\n";
             }
-
-        } elseif (is_object($obj) and $obj instanceof Literal) {
-            $atrributes = "";
+        } elseif (\is_object($obj) and $obj instanceof Literal) {
+            $atrributes = '';
             $datatype = $obj->getDatatypeUri();
             if ($datatype) {
-                if ($datatype == self::RDF_XML_LITERAL) {
-                    $atrributes .= " rdf:parseType=\"Literal\"";
-                    $value = strval($obj);
+                if (self::RDF_XML_LITERAL == $datatype) {
+                    $atrributes .= ' rdf:parseType="Literal"';
+                    $value = (string) $obj;
                 } else {
                     $datatype = htmlspecialchars($datatype);
                     $atrributes .= " rdf:datatype=\"$datatype\"";
@@ -115,19 +115,18 @@ class RdfXml extends Serialiser
 
             // Escape the value
             if (!isset($value)) {
-                $value = htmlspecialchars(strval($obj));
+                $value = htmlspecialchars((string) $obj);
             }
 
             return "{$indent}<{$property}{$atrributes}>{$value}</{$property}>\n";
         } else {
-            throw new Exception(
-                "Unable to serialise object to xml: ".getType($obj)
-            );
+            throw new Exception('Unable to serialise object to xml: '.\gettype($obj));
         }
     }
 
     /**
      * Protected method to serialise a whole resource and its properties
+     *
      * @ignore
      */
     protected function rdfxmlResource($res, $showNodeId, $depth = 1)
@@ -141,7 +140,7 @@ class RdfXml extends Serialiser
 
         // If the resource has no properties - don't serialise it
         $properties = $res->propertyUris();
-        if (count($properties) == 0) {
+        if (0 == \count($properties)) {
             return '';
         }
 
@@ -165,7 +164,7 @@ class RdfXml extends Serialiser
 
         if ($res instanceof Container) {
             foreach ($res as $item) {
-                $xml .= $this->rdfxmlObject('rdf:li', $item, $depth+1);
+                $xml .= $this->rdfxmlObject('rdf:li', $item, $depth + 1);
             }
         } else {
             foreach ($properties as $property) {
@@ -173,17 +172,14 @@ class RdfXml extends Serialiser
                 if ($short) {
                     $this->addPrefix($short);
                     $objects = $res->all("<$property>");
-                    if ($short == 'rdf:type' && $type != 'rdf:Description') {
+                    if ('rdf:type' == $short && 'rdf:Description' != $type) {
                         array_shift($objects);
                     }
                     foreach ($objects as $object) {
-                        $xml .= $this->rdfxmlObject($short, $object, $depth+1);
+                        $xml .= $this->rdfxmlObject($short, $object, $depth + 1);
                     }
                 } else {
-                    throw new Exception(
-                        "It is not possible to serialse the property ".
-                        "'$property' to RDF/XML."
-                    );
+                    throw new Exception('It is not possible to serialse the property '."'$property' to RDF/XML.");
                 }
             }
         }
@@ -192,32 +188,29 @@ class RdfXml extends Serialiser
         return $xml;
     }
 
-
     /**
      * Method to serialise an EasyRdf\Graph to RDF/XML
      *
-     * @param Graph  $graph  An EasyRdf\Graph object.
-     * @param string $format The name of the format to convert to.
-     * @param array  $options
+     * @param Graph  $graph  an EasyRdf\Graph object
+     * @param string $format the name of the format to convert to
      *
-     * @return string The RDF in the new desired format.
+     * @return string the RDF in the new desired format
+     *
      * @throws Exception
      */
-    public function serialise(Graph $graph, $format, array $options = array())
+    public function serialise(Graph $graph, $format, array $options = [])
     {
         parent::checkSerialiseParams($format);
 
-        if ($format != 'rdfxml') {
-            throw new Exception(
-                "EasyRdf\\Serialiser\\RdfXml does not support: {$format}"
-            );
+        if ('rdfxml' != $format) {
+            throw new Exception("EasyRdf\\Serialiser\\RdfXml does not support: {$format}");
         }
 
         // store of namespaces to be appended to the rdf:RDF tag
-        $this->prefixes = array('rdf' => true);
+        $this->prefixes = ['rdf' => true];
 
         // store of the resource URIs we have serialised
-        $this->outputtedResources = array();
+        $this->outputtedResources = [];
 
         $xml = '';
 
@@ -240,11 +233,11 @@ class RdfXml extends Serialiser
         foreach ($this->prefixes as $prefix => $count) {
             $url = RdfNamespace::get($prefix);
 
-            if (strlen($namespaceStr)) {
+            if (\strlen($namespaceStr)) {
                 $namespaceStr .= "\n        ";
             }
 
-            if (strlen($prefix) === 0) {
+            if (0 === \strlen($prefix)) {
                 $namespaceStr .= ' xmlns="'.htmlspecialchars($url).'"';
             } else {
                 $namespaceStr .= ' xmlns:'.$prefix.'="'.htmlspecialchars($url).'"';
@@ -252,6 +245,6 @@ class RdfXml extends Serialiser
         }
 
         return "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n".
-               "<rdf:RDF". $namespaceStr . ">\n" . $xml . "\n</rdf:RDF>\n";
+               '<rdf:RDF'.$namespaceStr.">\n".$xml."\n</rdf:RDF>\n";
     }
 }

--- a/lib/Sparql/Result.php
+++ b/lib/Sparql/Result.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Sparql;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -42,7 +43,6 @@ use EasyRdf\Resource;
 /**
  * Class for returned for SPARQL SELECT and ASK query responses.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
@@ -51,7 +51,7 @@ class Result extends \ArrayIterator
     private $type = null;
     private $boolean = null;
 
-    private $fields = array();
+    private $fields = [];
 
     /** A constant for the SPARQL Query Results XML Format namespace */
     const SPARQL_XML_RESULTS_NS = 'http://www.w3.org/2005/sparql-results#';
@@ -69,14 +69,12 @@ class Result extends \ArrayIterator
      */
     public function __construct($data, $mimeType)
     {
-        if ($mimeType == 'application/sparql-results+xml') {
+        if ('application/sparql-results+xml' == $mimeType) {
             $this->parseXml($data);
-        } elseif ($mimeType == 'application/sparql-results+json') {
+        } elseif ('application/sparql-results+json' == $mimeType) {
             $this->parseJson($data);
         } else {
-            throw new Exception(
-                "Unsupported SPARQL Query Results format: $mimeType"
-            );
+            throw new Exception("Unsupported SPARQL Query Results format: $mimeType");
         }
     }
 
@@ -85,7 +83,7 @@ class Result extends \ArrayIterator
      * ASK queries return a result of type 'boolean'.
      * SELECT query return a result of type 'bindings'.
      *
-     * @return string The query result type.
+     * @return string the query result type
      */
     public function getType()
     {
@@ -98,7 +96,7 @@ class Result extends \ArrayIterator
      * return either true or false. If the query was of some other
      * type then this method will return null.
      *
-     * @return boolean The result of the query.
+     * @return bool the result of the query
      */
     public function getBoolean()
     {
@@ -107,43 +105,43 @@ class Result extends \ArrayIterator
 
     /** Return true if the result of the query was true.
      *
-     * @return boolean True if the query result was true.
+     * @return bool true if the query result was true
      */
     public function isTrue()
     {
-        return $this->boolean == true;
+        return true == $this->boolean;
     }
 
     /** Return false if the result of the query was false.
      *
-     * @return boolean True if the query result was false.
+     * @return bool true if the query result was false
      */
     public function isFalse()
     {
-        return $this->boolean == false;
+        return false == $this->boolean;
     }
 
     /** Return the number of fields in a query result of type bindings.
      *
-     * @return integer The number of fields.
+     * @return int the number of fields
      */
     public function numFields()
     {
-        return count($this->fields);
+        return \count($this->fields);
     }
 
     /** Return the number of rows in a query result of type bindings.
      *
-     * @return integer The number of rows.
+     * @return int the number of rows
      */
     public function numRows()
     {
-        return count($this);
+        return \count($this);
     }
 
     /** Get the field names in a query result of type bindings.
      *
-     * @return array The names of the fields in the result.
+     * @return array the names of the fields in the result
      */
     public function getFields()
     {
@@ -155,51 +153,52 @@ class Result extends \ArrayIterator
      * This method is intended to be a debugging aid and will
      * return a pretty-print view of the query result.
      *
-     * @param  string  $format  Either 'text' or 'html'
+     * @param string $format Either 'text' or 'html'
      *
      * @throws Exception
+     *
      * @return string
      */
     public function dump($format = 'html')
     {
-        if ($this->type == 'bindings') {
+        if ('bindings' == $this->type) {
             $result = '';
-            if ($format == 'html') {
+            if ('html' == $format) {
                 $result .= "<table class='sparql-results' style='border-collapse:collapse'>";
-                $result .= "<tr>";
+                $result .= '<tr>';
                 foreach ($this->fields as $field) {
                     $result .= "<th style='border:solid 1px #000;padding:4px;".
                                "vertical-align:top;background-color:#eee;'>".
                                "?$field</th>";
                 }
-                $result .= "</tr>";
+                $result .= '</tr>';
                 foreach ($this as $row) {
-                    $result .= "<tr>";
+                    $result .= '<tr>';
                     foreach ($this->fields as $field) {
                         if (isset($row->$field)) {
                             $result .= "<td style='border:solid 1px #000;padding:4px;".
                                        "vertical-align:top'>".
-                                       $row->$field->dumpValue($format)."</td>";
+                                       $row->$field->dumpValue($format).'</td>';
                         } else {
-                            $result .= "<td>&nbsp;</td>";
+                            $result .= '<td>&nbsp;</td>';
                         }
                     }
-                    $result .= "</tr>";
+                    $result .= '</tr>';
                 }
-                $result .= "</table>";
+                $result .= '</table>';
             } else {
                 // First calculate the width of each comment
-                $colWidths = array();
+                $colWidths = [];
                 foreach ($this->fields as $field) {
-                    $colWidths[$field] = strlen($field);
+                    $colWidths[$field] = \strlen($field);
                 }
 
-                $textData = array();
+                $textData = [];
                 foreach ($this as $row) {
-                    $textRow = array();
+                    $textRow = [];
                     foreach ($row as $k => $v) {
                         $textRow[$k] = $v->dumpValue('text');
-                        $width = strlen($textRow[$k]);
+                        $width = \strlen($textRow[$k]);
                         if ($colWidths[$k] < $width) {
                             $colWidths[$k] = $width;
                         }
@@ -208,9 +207,9 @@ class Result extends \ArrayIterator
                 }
 
                 // Create a horizontal rule
-                $hr = "+";
+                $hr = '+';
                 foreach ($colWidths as $v) {
-                    $hr .= "-".str_repeat('-', $v).'-+';
+                    $hr .= '-'.str_repeat('-', $v).'-+';
                 }
 
                 // Output the field names
@@ -229,20 +228,18 @@ class Result extends \ArrayIterator
                     $result .= "\n";
                 }
                 $result .= "$hr\n";
-
             }
+
             return $result;
-        } elseif ($this->type == 'boolean') {
+        } elseif ('boolean' == $this->type) {
             $str = ($this->boolean ? 'true' : 'false');
-            if ($format == 'html') {
+            if ('html' == $format) {
                 return "<p>Result: <span style='font-weight:bold'>$str</span></p>";
             } else {
                 return "Result: $str";
             }
         } else {
-            throw new Exception(
-                "Failed to dump SPARQL Query Results format, unknown type: ". $this->type
-            );
+            throw new Exception('Failed to dump SPARQL Query Results format, unknown type: '.$this->type);
         }
     }
 
@@ -253,7 +250,7 @@ class Result extends \ArrayIterator
      */
     protected function newTerm($data)
     {
-        switch($data['type']) {
+        switch ($data['type']) {
             case 'bnode':
                 return new Resource('_:'.$data['value']);
             case 'uri':
@@ -262,10 +259,7 @@ class Result extends \ArrayIterator
             case 'typed-literal':
                 return Literal::create($data);
             default:
-                throw new Exception(
-                    "Failed to parse SPARQL Query Results format, unknown term type: ".
-                    $data['type']
-                );
+                throw new Exception('Failed to parse SPARQL Query Results format, unknown term type: '.$data['type']);
         }
     }
 
@@ -278,26 +272,25 @@ class Result extends \ArrayIterator
         $doc = new \DOMDocument();
         $doc->loadXML($data, LIBXML_PARSEHUGE);
 
-        # Check for valid root node.
-        if ($doc->hasChildNodes() == false or
-            $doc->childNodes->length != 1 or
-            $doc->firstChild->nodeName != 'sparql' or
-            $doc->firstChild->namespaceURI != self::SPARQL_XML_RESULTS_NS) {
-            throw new Exception(
-                "Incorrect root node in SPARQL XML Query Results format"
-            );
+        // Check for valid root node.
+        if (false == $doc->hasChildNodes() or
+            1 != $doc->childNodes->length or
+            'sparql' != $doc->firstChild->nodeName or
+            self::SPARQL_XML_RESULTS_NS != $doc->firstChild->namespaceURI) {
+            throw new Exception('Incorrect root node in SPARQL XML Query Results format');
         }
 
-        # Is it the result of an ASK query?
+        // Is it the result of an ASK query?
         $boolean = $doc->getElementsByTagName('boolean');
         if ($boolean->length) {
             $this->type = 'boolean';
             $value = $boolean->item(0)->nodeValue;
-            $this->boolean = $value == 'true' ? true : false;
+            $this->boolean = 'true' == $value ? true : false;
+
             return;
         }
 
-        # Get a list of variables from the header
+        // Get a list of variables from the header
         $head = $doc->getElementsByTagName('head');
         if ($head->length) {
             $variables = $head->item(0)->getElementsByTagName('variable');
@@ -306,7 +299,7 @@ class Result extends \ArrayIterator
             }
         }
 
-        # Is it the result of a SELECT query?
+        // Is it the result of a SELECT query?
         $resultstag = $doc->getElementsByTagName('results');
         if ($resultstag->length) {
             $this->type = 'bindings';
@@ -317,28 +310,27 @@ class Result extends \ArrayIterator
                 foreach ($bindings as $binding) {
                     $key = $binding->getAttribute('name');
                     foreach ($binding->childNodes as $node) {
-                        if ($node->nodeType != XML_ELEMENT_NODE) {
+                        if (XML_ELEMENT_NODE != $node->nodeType) {
                             continue;
                         }
                         $t->$key = $this->newTerm(
-                            array(
+                            [
                                 'type' => $node->nodeName,
                                 'value' => $node->nodeValue,
                                 'lang' => $node->getAttribute('xml:lang'),
-                                'datatype' => $node->getAttribute('datatype')
-                            )
+                                'datatype' => $node->getAttribute('datatype'),
+                            ]
                         );
                         break;
                     }
                 }
                 $this[] = $t;
             }
+
             return;
         }
 
-        throw new Exception(
-            "Failed to parse SPARQL XML Query Results format"
-        );
+        throw new Exception('Failed to parse SPARQL XML Query Results format');
     }
 
     /** Parse a SPARQL result in the JSON format into the object.
@@ -367,9 +359,7 @@ class Result extends \ArrayIterator
                 $this[] = $t;
             }
         } else {
-            throw new Exception(
-                "Failed to parse SPARQL JSON Query Results format"
-            );
+            throw new Exception('Failed to parse SPARQL JSON Query Results format');
         }
     }
 
@@ -378,11 +368,11 @@ class Result extends \ArrayIterator
      * If this is a boolean result then it will return 'true' or 'false'.
      * If it is a bindings type, then it will dump as a text based table.
      *
-     * @return string A string representation of the result.
+     * @return string a string representation of the result
      */
     public function __toString()
     {
-        if ($this->type == 'boolean') {
+        if ('boolean' == $this->type) {
             return $this->boolean ? 'true' : 'false';
         } else {
             return $this->dump('text');

--- a/lib/TypeMapper.php
+++ b/lib/TypeMapper.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EasyRdf;
 
 /**
@@ -31,7 +32,6 @@ namespace EasyRdf;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
@@ -39,14 +39,13 @@ namespace EasyRdf;
 /**
  * Class to map between RDF Types and PHP Classes
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
 class TypeMapper
 {
     /** The type map registry */
-    private static $map = array();
+    private static $map = [];
 
     /** Default resource class */
     private static $defaultResourceClass = 'EasyRdf\Resource';
@@ -55,21 +54,20 @@ class TypeMapper
      *
      * If a type is not registered, then this method will return null.
      *
-     * @param  string  $type   The RDF type (e.g. foaf:Person)
+     * @param string $type The RDF type (e.g. foaf:Person)
      *
      * @throws \InvalidArgumentException
-     * @return string          The class name (e.g. Model_Foaf_Name)
+     *
+     * @return string The class name (e.g. Model_Foaf_Name)
      */
     public static function get($type)
     {
-        if (!is_string($type) or $type == null or $type == '') {
-            throw new \InvalidArgumentException(
-                "\$type should be a string and cannot be null or empty"
-            );
+        if (!\is_string($type) or null == $type or '' == $type) {
+            throw new \InvalidArgumentException('$type should be a string and cannot be null or empty');
         }
 
         $type = RdfNamespace::expand($type);
-        if (array_key_exists($type, self::$map)) {
+        if (\array_key_exists($type, self::$map)) {
             return self::$map[$type];
         } else {
             return null;
@@ -78,43 +76,39 @@ class TypeMapper
 
     /** Register an RDF type with a PHP Class name
      *
-     * @param  string  $type   The RDF type (e.g. foaf:Person)
-     * @param  string  $class  The PHP class name (e.g. Model_Foaf_Name)
+     * @param string $type  The RDF type (e.g. foaf:Person)
+     * @param string $class The PHP class name (e.g. Model_Foaf_Name)
      *
      * @throws \InvalidArgumentException
-     * @return string          The PHP class name
+     *
+     * @return string The PHP class name
      */
     public static function set($type, $class)
     {
-        if (!is_string($type) or $type == null or $type == '') {
-            throw new \InvalidArgumentException(
-                "\$type should be a string and cannot be null or empty"
-            );
+        if (!\is_string($type) or null == $type or '' == $type) {
+            throw new \InvalidArgumentException('$type should be a string and cannot be null or empty');
         }
 
-        if (!is_string($class) or $class == null or $class == '') {
-            throw new \InvalidArgumentException(
-                "\$class should be a string and cannot be null or empty"
-            );
+        if (!\is_string($class) or null == $class or '' == $class) {
+            throw new \InvalidArgumentException('$class should be a string and cannot be null or empty');
         }
 
         $type = RdfNamespace::expand($type);
+
         return self::$map[$type] = $class;
     }
 
     /**
-      * Delete an existing RDF type mapping.
-      *
-      * @param  string  $type   The RDF type (e.g. foaf:Person)
-      *
-      * @throws \InvalidArgumentException
-      */
+     * Delete an existing RDF type mapping.
+     *
+     * @param string $type The RDF type (e.g. foaf:Person)
+     *
+     * @throws \InvalidArgumentException
+     */
     public static function delete($type)
     {
-        if (!is_string($type) or $type == null or $type == '') {
-            throw new \InvalidArgumentException(
-                "\$type should be a string and cannot be null or empty"
-            );
+        if (!\is_string($type) or null == $type or '' == $type) {
+            throw new \InvalidArgumentException('$type should be a string and cannot be null or empty');
         }
 
         $type = RdfNamespace::expand($type);
@@ -124,7 +118,7 @@ class TypeMapper
     }
 
     /**
-     * @return string           The default Resource class
+     * @return string The default Resource class
      */
     public static function getDefaultResourceClass()
     {
@@ -134,36 +128,30 @@ class TypeMapper
     /**
      * Sets the default resource class
      *
-     * @param  string $class The resource full class name (e.g. \MyCompany\Resource)
+     * @param string $class The resource full class name (e.g. \MyCompany\Resource)
      *
      * @throws \InvalidArgumentException
-     * @return string           The default Resource class
+     *
+     * @return string The default Resource class
      */
     public static function setDefaultResourceClass($class)
     {
-        if (!is_string($class) or $class == null or $class == '') {
-            throw new \InvalidArgumentException(
-                "\$class should be a string and cannot be null or empty"
-            );
+        if (!\is_string($class) or null == $class or '' == $class) {
+            throw new \InvalidArgumentException('$class should be a string and cannot be null or empty');
         }
 
         if (!class_exists($class)) {
-            throw new \InvalidArgumentException(
-                "Given class should be an existing class"
-            );
+            throw new \InvalidArgumentException('Given class should be an existing class');
         }
 
         $ancestors = class_parents($class);
-        if (($class != 'EasyRdf\Resource') && (empty($ancestors) || !in_array('EasyRdf\Resource', $ancestors))) {
-            throw new \InvalidArgumentException(
-                "Given class should have EasyRdf\\Resource as an ancestor"
-            );
+        if (('EasyRdf\Resource' != $class) && (empty($ancestors) || !\in_array('EasyRdf\Resource', $ancestors))) {
+            throw new \InvalidArgumentException('Given class should have EasyRdf\\Resource as an ancestor');
         }
 
         return self::$defaultResourceClass = $class;
     }
 }
-
 
 /*
    Register default set of mapped types

--- a/lib/Utils.php
+++ b/lib/Utils.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EasyRdf;
 
 /**
@@ -31,22 +32,18 @@ namespace EasyRdf;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
 
-
 /**
  * Class containing static utility functions
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
 class Utils
 {
-
     /**
      * Convert a string into CamelCase
      *
@@ -66,6 +63,7 @@ class Utils
         foreach (preg_split('/[\W_]+/', $str) as $part) {
             $cc .= ucfirst(strtolower($part));
         }
+
         return $cc;
     }
 
@@ -80,9 +78,9 @@ class Utils
      */
     public static function isAssociativeArray($param)
     {
-        if (is_array($param)) {
+        if (\is_array($param)) {
             $keys = array_keys($param);
-            if ($keys[0] === 0) {
+            if (0 === $keys[0]) {
                 return false;
             } else {
                 return true;
@@ -102,7 +100,7 @@ class Utils
     public static function removeFragmentFromUri($uri)
     {
         $pos = strpos($uri, '#');
-        if ($pos === false) {
+        if (false === $pos) {
             return $uri;
         } else {
             return substr($uri, 0, $pos);
@@ -115,32 +113,31 @@ class Utils
      * EasyRdf\Graph and EasyRdf\Sparql\Result to format a resource
      * for display.
      *
-     * @param  mixed  $resource An EasyRdf\Resource object or an associative array
-     * @param  string $format   Either 'html' or 'text'
-     * @param  string $color    The colour of the text
+     * @param mixed  $resource An EasyRdf\Resource object or an associative array
+     * @param string $format   Either 'html' or 'text'
+     * @param string $color    The colour of the text
      *
      * @throws \InvalidArgumentException
+     *
      * @return string
      */
     public static function dumpResourceValue($resource, $format = 'html', $color = 'blue')
     {
         if (!preg_match('/^#?[-\w]+$/', $color)) {
-            throw new \InvalidArgumentException(
-                "\$color must be a legal color code or name"
-            );
+            throw new \InvalidArgumentException('$color must be a legal color code or name');
         }
 
-        if (is_object($resource)) {
-            $resource = strval($resource);
-        } elseif (is_array($resource)) {
+        if (\is_object($resource)) {
+            $resource = (string) $resource;
+        } elseif (\is_array($resource)) {
             $resource = $resource['value'];
         }
 
         $short = RdfNamespace::shorten($resource);
-        if ($format == 'html') {
+        if ('html' == $format) {
             $escaped = htmlentities($resource, ENT_QUOTES);
-            if (substr($resource, 0, 2) == '_:') {
-                $href = '#' . $escaped;
+            if ('_:' == substr($resource, 0, 2)) {
+                $href = '#'.$escaped;
             } else {
                 $href = $escaped;
             }
@@ -164,44 +161,43 @@ class Utils
      * EasyRdf\Graph and EasyRdf\Sparql\Result to format a literal
      * for display.
      *
-     * @param  mixed  $literal  An EasyRdf\Literal object or an associative array
-     * @param  string $format   Either 'html' or 'text'
-     * @param  string $color    The colour of the text
+     * @param mixed  $literal An EasyRdf\Literal object or an associative array
+     * @param string $format  Either 'html' or 'text'
+     * @param string $color   The colour of the text
      *
      * @throws \InvalidArgumentException
+     *
      * @return string
      */
     public static function dumpLiteralValue($literal, $format = 'html', $color = 'black')
     {
         if (!preg_match('/^#?[-\w]+$/', $color)) {
-            throw new \InvalidArgumentException(
-                "\$color must be a legal color code or name"
-            );
+            throw new \InvalidArgumentException('$color must be a legal color code or name');
         }
 
-        if (is_object($literal)) {
+        if (\is_object($literal)) {
             $literal = $literal->toRdfPhp();
-        } elseif (!is_array($literal)) {
-            $literal = array('value' => $literal);
+        } elseif (!\is_array($literal)) {
+            $literal = ['value' => $literal];
         }
 
         $text = '"'.$literal['value'].'"';
         if (isset($literal['lang'])) {
-            $text .= '@' . $literal['lang'];
+            $text .= '@'.$literal['lang'];
         }
         if (isset($literal['datatype'])) {
             $short = RdfNamespace::shorten($literal['datatype']);
             if ($short) {
                 $text .= "^^$short";
             } else {
-                $text .= "^^<".$literal['datatype'].">";
+                $text .= '^^<'.$literal['datatype'].'>';
             }
         }
 
-        if ($format == 'html') {
+        if ('html' == $format) {
             return "<span style='color:$color'>".
-                   htmlentities($text, ENT_COMPAT, "UTF-8").
-                   "</span>";
+                   htmlentities($text, ENT_COMPAT, 'UTF-8').
+                   '</span>';
         } else {
             return $text;
         }
@@ -209,21 +205,22 @@ class Utils
 
     /** Clean up and split a mime-type up into its parts
      *
-     * @param  string $mimeType   A MIME Type, optionally with parameters
+     * @param string $mimeType A MIME Type, optionally with parameters
      *
-     * @return array  $type, $parameters
+     * @return array $type, $parameters
      */
     public static function parseMimeType($mimeType)
     {
         $parts = explode(';', strtolower($mimeType));
         $type = trim(array_shift($parts));
-        $params = array();
+        $params = [];
         foreach ($parts as $part) {
             if (preg_match('/^\s*(\w+)\s*=\s*(.+?)\s*$/', $part, $matches)) {
                 $params[$matches[1]] = $matches[2];
             }
         }
-        return array($type, $params);
+
+        return [$type, $params];
     }
 
     /** Execute a command as a pipe
@@ -233,31 +230,32 @@ class Utils
      * and throwing an exception if anything is written to STDERR or the
      * process returns non-zero.
      *
-     * @param  string $command The command to execute
-     * @param  array  $args    Optional list of arguments to pass to the command
-     * @param  string $input   Optional buffer to send to the command
-     * @param  string $dir     Path to directory to run command in (defaults to /tmp)
+     * @param string $command The command to execute
+     * @param array  $args    Optional list of arguments to pass to the command
+     * @param string $input   Optional buffer to send to the command
+     * @param string $dir     Path to directory to run command in (defaults to /tmp)
      *
      * @throws Exception
+     *
      * @return string The result of the command, printed to STDOUT
      */
     public static function execCommandPipe($command, $args = null, $input = null, $dir = null)
     {
-        $descriptorspec = array(
-            0 => array('pipe', 'r'),
-            1 => array('pipe', 'w'),
-            2 => array('pipe', 'w')
-        );
+        $descriptorspec = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
 
         // Use the system tmp directory by default
         if (!$dir) {
             $dir = sys_get_temp_dir();
         }
 
-        if (is_array($args)) {
+        if (\is_array($args)) {
             $fullCommand = implode(
                 ' ',
-                array_map('escapeshellcmd', array_merge(array($command), $args))
+                array_map('escapeshellcmd', array_merge([$command], $args))
             );
         } else {
             $fullCommand = escapeshellcmd($command);
@@ -267,7 +265,7 @@ class Utils
         }
 
         $process = proc_open($fullCommand, $descriptorspec, $pipes, $dir);
-        if (is_resource($process)) {
+        if (\is_resource($process)) {
             // $pipes now looks like this:
             // 0 => writeable handle connected to child stdin
             // 1 => readable handle connected to child stdout
@@ -287,14 +285,10 @@ class Utils
             // proc_close in order to avoid a deadlock
             $returnValue = proc_close($process);
             if ($returnValue) {
-                throw new Exception(
-                    "Error while executing command $command: ".$error
-                );
+                throw new Exception("Error while executing command $command: ".$error);
             }
         } else {
-            throw new Exception(
-                "Failed to execute command $command"
-            );
+            throw new Exception("Failed to execute command $command");
         }
 
         return $output;

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -37,9 +37,4 @@
         <directory suffix=".php">../lib/EasyRdf/</directory>
       </whitelist>
     </filter>
-
-    <logging>
-        <log type="junit" target="reports/test-results.xml" />
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
 </phpunit>

--- a/test/EasyRdf/CollectionTest.php
+++ b/test/EasyRdf/CollectionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EasyRdf;
 
 /**
@@ -31,12 +32,10 @@ namespace EasyRdf;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
-
-require_once dirname(__DIR__).DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(__DIR__).\DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class CollectionTest extends TestCase
 {
@@ -79,13 +78,13 @@ class CollectionTest extends TestCase
 
         $this->assertFalse($pets->valid());
         $this->assertSame(4, $pets->key());
-        $this->assertSame(null, $pets->current());
+        $this->assertNull($pets->current());
 
         $pets->next();
 
         $this->assertFalse($pets->valid());
         $this->assertSame(5, $pets->key());
-        $this->assertSame(null, $pets->current());
+        $this->assertNull($pets->current());
 
         $pets->rewind();
 
@@ -101,17 +100,17 @@ class CollectionTest extends TestCase
         $owner = $this->graph->resource('ex:owner');
         $pets = $owner->get('ex:pets');
 
-        $list = array();
+        $list = [];
         foreach ($pets as $pet) {
             $list[] = $pet->getUri();
         }
 
         $this->assertEquals(
-            array(
+            [
                 'http://example.org/rat',
                 'http://example.org/cat',
-                'http://example.org/goat'
-            ),
+                'http://example.org/goat',
+            ],
             $list
         );
     }
@@ -181,14 +180,14 @@ class CollectionTest extends TestCase
     public function testCountEmpty()
     {
         $list = $this->graph->newBnode('rdf:List');
-        $this->assertSame(0, count($list));
+        $this->assertSame(0, \count($list));
     }
 
     public function testCountOne()
     {
         $list = $this->graph->newBnode('rdf:List');
         $list->append('Item');
-        $this->assertSame(1, count($list));
+        $this->assertSame(1, \count($list));
     }
 
     public function testCountTwo()
@@ -196,7 +195,7 @@ class CollectionTest extends TestCase
         $list = $this->graph->newBnode('rdf:List');
         $list->append('Item 1');
         $list->append('Item 2');
-        $this->assertSame(2, count($list));
+        $this->assertSame(2, \count($list));
     }
 
     public function testCountThree()
@@ -205,7 +204,7 @@ class CollectionTest extends TestCase
         $list->append('Item 1');
         $list->append('Item 2');
         $list->append('Item 3');
-        $this->assertSame(3, count($list));
+        $this->assertSame(3, \count($list));
     }
 
     public function testArrayOffsetExists()
@@ -261,7 +260,6 @@ class CollectionTest extends TestCase
         $list = $this->graph->newBnode('rdf:List');
         isset($list['foo']);
     }
-
 
     public function testArrayOffsetGet()
     {
@@ -326,13 +324,13 @@ class CollectionTest extends TestCase
         $list[2] = 'Item 2';
         $list[3] = 'Item 3';
 
-        $strings = array();
+        $strings = [];
         foreach ($list as $item) {
-            $strings[] = strval($item);
+            $strings[] = (string) $item;
         }
 
         $this->assertEquals(
-            array('Item 1', 'Item 2', 'Item 3'),
+            ['Item 1', 'Item 2', 'Item 3'],
             $strings
         );
     }
@@ -502,13 +500,13 @@ class CollectionTest extends TestCase
         $this->assertEquals(1, $animals->append('Cat'));
         $this->assertEquals(1, $animals->append('Dog'));
 
-        $list = array();
+        $list = [];
         foreach ($animals as $animal) {
-            $list[] = strval($animal);
+            $list[] = (string) $animal;
         }
 
         $this->assertEquals(
-            array('Rat', 'Cat', 'Dog'),
+            ['Rat', 'Cat', 'Dog'],
             $list
         );
     }

--- a/test/EasyRdf/ContainerTest.php
+++ b/test/EasyRdf/ContainerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EasyRdf;
 
 /**
@@ -31,12 +32,10 @@ namespace EasyRdf;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
-
-require_once dirname(__DIR__).DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(__DIR__).\DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class ContainerTest extends TestCase
 {
@@ -63,35 +62,35 @@ class ContainerTest extends TestCase
         $this->assertSame('rdf:Seq', $favourites->type());
         $this->assertClass('EasyRdf\Container', $favourites);
 
-        $this->assertSame(true, $favourites->valid());
+        $this->assertTrue($favourites->valid());
         $this->assertSame(1, $favourites->key());
         $this->assertStringEquals('http://example.org/banana', $favourites->current());
 
         $favourites->next();
 
-        $this->assertSame(true, $favourites->valid());
+        $this->assertTrue($favourites->valid());
         $this->assertSame(2, $favourites->key());
         $this->assertStringEquals('http://example.org/apple', $favourites->current());
 
         $favourites->next();
 
-        $this->assertSame(true, $favourites->valid());
+        $this->assertTrue($favourites->valid());
         $this->assertSame(3, $favourites->key());
         $this->assertStringEquals('http://example.org/pear', $favourites->current());
 
         $favourites->next();
 
-        $this->assertSame(true, $favourites->valid());
+        $this->assertTrue($favourites->valid());
         $this->assertSame(4, $favourites->key());
         $this->assertStringEquals('http://example.org/pear', $favourites->current());
 
         $favourites->next();
 
-        $this->assertSame(false, $favourites->valid());
+        $this->assertFalse($favourites->valid());
 
         $favourites->rewind();
 
-        $this->assertSame(true, $favourites->valid());
+        $this->assertTrue($favourites->valid());
         $this->assertSame(1, $favourites->key());
         $this->assertStringEquals('http://example.org/banana', $favourites->current());
     }
@@ -106,18 +105,18 @@ class ContainerTest extends TestCase
 
         $favourites = $this->graph->resource('ex:favourite-fruit');
 
-        $list = array();
+        $list = [];
         foreach ($favourites as $fruit) {
             $list[] = $fruit->getUri();
         }
 
         $this->assertEquals(
-            array(
+            [
                 'http://example.org/banana',
                 'http://example.org/apple',
                 'http://example.org/pear',
-                'http://example.org/pear'
-            ),
+                'http://example.org/pear',
+            ],
             $list
         );
     }
@@ -193,14 +192,14 @@ class ContainerTest extends TestCase
     public function testCountEmpty()
     {
         $seq = $this->graph->newBnode('rdf:Seq');
-        $this->assertSame(0, count($seq));
+        $this->assertSame(0, \count($seq));
     }
 
     public function testCountOne()
     {
         $seq = $this->graph->newBnode('rdf:Seq');
         $seq->add('rdf:_1', 'Item');
-        $this->assertSame(1, count($seq));
+        $this->assertSame(1, \count($seq));
     }
 
     public function testCountTwo()
@@ -208,7 +207,7 @@ class ContainerTest extends TestCase
         $seq = $this->graph->newBnode('rdf:Seq');
         $seq->add('rdf:_1', 'Item 1');
         $seq->add('rdf:_2', 'Item 2');
-        $this->assertSame(2, count($seq));
+        $this->assertSame(2, \count($seq));
     }
 
     public function testArrayOffsetExists()

--- a/test/EasyRdf/ExceptionTest.php
+++ b/test/EasyRdf/ExceptionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EasyRdf;
 
 /**
@@ -31,12 +32,10 @@ namespace EasyRdf;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
-
-require_once dirname(__DIR__).DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(__DIR__).\DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class ExceptionTest extends TestCase
 {

--- a/test/EasyRdf/FormatTest.php
+++ b/test/EasyRdf/FormatTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EasyRdf;
 
 /**
@@ -31,12 +32,10 @@ namespace EasyRdf;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
-
-require_once dirname(__DIR__).DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(__DIR__).\DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class MockParserClass
 {
@@ -60,8 +59,8 @@ class FormatTest extends TestCase
             'my',
             'My Format',
             'http://example.com/myformat',
-            array('my/mime' => 1.0, 'my/x-mime' => 0.9),
-            array('mext')
+            ['my/mime' => 1.0, 'my/x-mime' => 0.9],
+            ['mext']
         );
     }
 
@@ -94,14 +93,14 @@ class FormatTest extends TestCase
             'InvalidArgumentException',
             '$name should be a string and cannot be null or empty'
         );
-        Format::register(array());
+        Format::register([]);
     }
 
     public function testGetFormats()
     {
         $formats = Format::getFormats();
         $this->assertInternalType('array', $formats);
-        $this->assertGreaterThan(0, count($formats));
+        $this->assertGreaterThan(0, \count($formats));
         foreach ($formats as $format) {
             $this->assertClass('EasyRdf\Format', $format);
         }
@@ -116,7 +115,7 @@ class FormatTest extends TestCase
 
     public function testGetHttpAcceptHeaderWithExtra()
     {
-        $accept = Format::getHttpAcceptHeader(array('extra/header' => 0.5));
+        $accept = Format::getHttpAcceptHeader(['extra/header' => 0.5]);
         $this->assertContains('application/json', $accept);
         $this->assertContains('extra/header;q=0.5', $accept);
     }
@@ -126,7 +125,7 @@ class FormatTest extends TestCase
         $current_locale = setlocale(LC_NUMERIC, 0);
         setlocale(LC_NUMERIC, 'fi_FI.UTF-8');
 
-        $accept = Format::getHttpAcceptHeader(array('extra/header' => 0.5));
+        $accept = Format::getHttpAcceptHeader(['extra/header' => 0.5]);
         $this->assertContains('extra/header;q=0.5', $accept);
 
         setlocale(LC_NUMERIC, $current_locale);
@@ -222,7 +221,7 @@ class FormatTest extends TestCase
             'InvalidArgumentException',
             '$query should be a string and cannot be null or empty'
         );
-        Format::getFormat(array());
+        Format::getFormat([]);
     }
 
     public function testGetFormatUnknown()
@@ -231,14 +230,14 @@ class FormatTest extends TestCase
             'EasyRdf\Exception',
             'Format is not recognised: unknown'
         );
-        $this->assertSame(null, Format::getFormat('unknown'));
+        $this->assertNull(Format::getFormat('unknown'));
     }
 
     public function testGetNames()
     {
         $names = Format::getNames();
-        $this->assertTrue(is_array($names));
-        $this->assertTrue(in_array('ntriples', $names));
+        $this->assertTrue(\is_array($names));
+        $this->assertTrue(\in_array('ntriples', $names));
     }
 
     public function testGetName()
@@ -260,13 +259,13 @@ class FormatTest extends TestCase
     public function testSetLabelNull()
     {
         $this->format->setLabel(null);
-        $this->assertSame(null, $this->format->getLabel());
+        $this->assertNull($this->format->getLabel());
     }
 
     public function testSetLabelEmpty()
     {
         $this->format->setLabel('');
-        $this->assertSame(null, $this->format->getLabel());
+        $this->assertNull($this->format->getLabel());
     }
 
     public function testSetLabelNonString()
@@ -287,13 +286,13 @@ class FormatTest extends TestCase
     public function testSetUriNull()
     {
         $this->format->setUri(null);
-        $this->assertSame(null, $this->format->getUri());
+        $this->assertNull($this->format->getUri());
     }
 
     public function testSetUriEmpty()
     {
         $this->format->setUri('');
-        $this->assertSame(null, $this->format->getUri());
+        $this->assertNull($this->format->getUri());
     }
 
     public function testSetUriNonString()
@@ -332,7 +331,7 @@ class FormatTest extends TestCase
     public function testGetMimeTypes()
     {
         $this->assertSame(
-            array('my/mime' => 1.0, 'my/x-mime' => 0.9),
+            ['my/mime' => 1.0, 'my/x-mime' => 0.9],
             $this->format->getMimeTypes()
         );
     }
@@ -341,7 +340,7 @@ class FormatTest extends TestCase
     {
         $this->format->setMimeTypes('testSetMimeType');
         $this->assertSame(
-            array('testSetMimeType'),
+            ['testSetMimeType'],
             $this->format->getMimeTypes()
         );
     }
@@ -349,10 +348,10 @@ class FormatTest extends TestCase
     public function testSetMimeTypes()
     {
         $this->format->setMimeTypes(
-            array('testSetMimeTypes1', 'testSetMimeTypes2')
+            ['testSetMimeTypes1', 'testSetMimeTypes2']
         );
         $this->assertSame(
-            array('testSetMimeTypes1', 'testSetMimeTypes2'),
+            ['testSetMimeTypes1', 'testSetMimeTypes2'],
             $this->format->getMimeTypes()
         );
     }
@@ -360,7 +359,7 @@ class FormatTest extends TestCase
     public function testSetMimeTypeNull()
     {
         $this->format->setMimeTypes(null);
-        $this->assertSame(array(), $this->format->getMimeTypes());
+        $this->assertSame([], $this->format->getMimeTypes());
     }
 
     public function testGetDefaultExtension()
@@ -382,7 +381,7 @@ class FormatTest extends TestCase
     public function testGetExtensions()
     {
         $this->assertSame(
-            array('mext'),
+            ['mext'],
             $this->format->getExtensions()
         );
     }
@@ -391,7 +390,7 @@ class FormatTest extends TestCase
     {
         $this->format->setExtensions('testSetExtension');
         $this->assertSame(
-            array('testSetExtension'),
+            ['testSetExtension'],
             $this->format->getExtensions()
         );
     }
@@ -399,10 +398,10 @@ class FormatTest extends TestCase
     public function testSetExtensions()
     {
         $this->format->setExtensions(
-            array('ext1', 'ext2')
+            ['ext1', 'ext2']
         );
         $this->assertSame(
-            array('ext1', 'ext2'),
+            ['ext1', 'ext2'],
             $this->format->getExtensions()
         );
     }
@@ -410,7 +409,7 @@ class FormatTest extends TestCase
     public function testSetExtensionsNull()
     {
         $this->format->setExtensions(null);
-        $this->assertSame(array(), $this->format->getExtensions());
+        $this->assertSame([], $this->format->getExtensions());
     }
 
     public function testToString()
@@ -430,13 +429,13 @@ class FormatTest extends TestCase
     public function testSetParserClassNull()
     {
         $this->format->setParserClass(null);
-        $this->assertSame(null, $this->format->getParserClass());
+        $this->assertNull($this->format->getParserClass());
     }
 
     public function testSetParserClassEmpty()
     {
         $this->format->setParserClass('');
-        $this->assertSame(null, $this->format->getParserClass());
+        $this->assertNull($this->format->getParserClass());
     }
 
     public function testSetParserClassNonString()
@@ -495,13 +494,13 @@ class FormatTest extends TestCase
     public function testSetSerialiserClassNull()
     {
         $this->format->setSerialiserClass(null);
-        $this->assertSame(null, $this->format->getSerialiserClass());
+        $this->assertNull($this->format->getSerialiserClass());
     }
 
     public function testSetSerialiserClassEmpty()
     {
         $this->format->setSerialiserClass('');
-         $this->assertSame(null, $this->format->getSerialiserClass());
+        $this->assertNull($this->format->getSerialiserClass());
     }
 
     public function testSetSerialiserClassNonString()
@@ -556,7 +555,7 @@ class FormatTest extends TestCase
 
     public function testGuessFormatPhp()
     {
-        $data = array('http://www.example.com' => array());
+        $data = ['http://www.example.com' => []];
         $this->assertStringEquals('php', Format::guessFormat($data));
     }
 
@@ -645,7 +644,7 @@ class FormatTest extends TestCase
 
     public function testGuessFormatHtml()
     {
-        # We don't support any other microformats embedded in HTML
+        // We don't support any other microformats embedded in HTML
         $format = Format::guessFormat(
             '<html><head><title>Hello</title></head><body><h1>Hello World</h1></body></html>'
         );
@@ -660,11 +659,11 @@ class FormatTest extends TestCase
 
     public function testGuessFormatXml()
     {
-        # We support several different XML formats, don't know which one this is...
+        // We support several different XML formats, don't know which one this is...
         $format = Format::guessFormat(
             '<?xml version="1.0" encoding="UTF-8"?>'
         );
-        $this->assertSame(null, $format);
+        $this->assertNull($format);
     }
 
     public function testGuessFormatByFilenameTtl()

--- a/test/EasyRdf/GraphStoreTest.php
+++ b/test/EasyRdf/GraphStoreTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -38,8 +39,7 @@ namespace EasyRdf;
 
 use EasyRdf\Http\MockClient;
 
-require_once dirname(__DIR__).DIRECTORY_SEPARATOR.'TestHelper.php';
-
+require_once \dirname(__DIR__).\DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class GraphStoreTest extends TestCase
 {
@@ -108,7 +108,7 @@ class GraphStoreTest extends TestCase
         );
         $graph = $this->graphStore->getDefault();
         $this->assertClass('EasyRdf\Graph', $graph);
-        $this->assertSame(null, $graph->getUri());
+        $this->assertNull($graph->getUri());
         $this->assertStringEquals(
             'Joe Bloggs',
             $graph->get('http://www.example.com/joe#me', 'foaf:name')
@@ -143,7 +143,7 @@ class GraphStoreTest extends TestCase
             'DELETE',
             'http://localhost:8080/data/filenotfound',
             'Graph not found.',
-            array('status' => 404)
+            ['status' => 404]
         );
         $this->setExpectedException(
             'EasyRdf\Exception',
@@ -158,7 +158,8 @@ class GraphStoreTest extends TestCase
             "<urn:subject> <urn:predicate> \"object\" .\n",
             $client->getRawData()
         );
-        $this->assertSame("application/n-triples", $client->getHeader('Content-Type'));
+        $this->assertSame('application/n-triples', $client->getHeader('Content-Type'));
+
         return true;
     }
 
@@ -170,7 +171,7 @@ class GraphStoreTest extends TestCase
             'POST',
             'http://localhost:8080/data/new.rdf',
             'OK',
-            array('callback' => array($this, 'checkNtriplesRequest'))
+            ['callback' => [$this, 'checkNtriplesRequest']]
         );
         $response = $this->graphStore->insert($graph);
         $this->assertSame(200, $response->getStatus());
@@ -183,9 +184,9 @@ class GraphStoreTest extends TestCase
             'POST',
             '/data/?graph=http%3A%2F%2Ffoo.com%2Fbar.rdf',
             'OK',
-            array('callback' => array($this, 'checkNtriplesRequest'))
+            ['callback' => [$this, 'checkNtriplesRequest']]
         );
-        $response = $this->graphStore->insert($data, "http://foo.com/bar.rdf");
+        $response = $this->graphStore->insert($data, 'http://foo.com/bar.rdf');
         $this->assertSame(200, $response->getStatus());
     }
 
@@ -196,7 +197,7 @@ class GraphStoreTest extends TestCase
             'POST',
             '/data/?default',
             'OK',
-            array('callback' => array($this, 'checkNtriplesRequest'))
+            ['callback' => [$this, 'checkNtriplesRequest']]
         );
         $response = $this->graphStore->insertIntoDefault($data);
         $this->assertSame(200, $response->getStatus());
@@ -209,7 +210,7 @@ class GraphStoreTest extends TestCase
             'POST',
             '/data/new.rdf',
             'Internal Server Error',
-            array('status' => 500)
+            ['status' => 500]
         );
         $this->setExpectedException(
             'EasyRdf\Exception',
@@ -225,9 +226,9 @@ class GraphStoreTest extends TestCase
             'PUT',
             '/data/?graph=http%3A%2F%2Ffoo.com%2Fbar.rdf',
             'OK',
-            array('callback' => array($this, 'checkNtriplesRequest'))
+            ['callback' => [$this, 'checkNtriplesRequest']]
         );
-        $response = $this->graphStore->replace($data, "http://foo.com/bar.rdf");
+        $response = $this->graphStore->replace($data, 'http://foo.com/bar.rdf');
         $this->assertSame(200, $response->getStatus());
     }
 
@@ -238,7 +239,7 @@ class GraphStoreTest extends TestCase
             'PUT',
             '/data/?default',
             'OK',
-            array('callback' => array($this, 'checkNtriplesRequest'))
+            ['callback' => [$this, 'checkNtriplesRequest']]
         );
         $response = $this->graphStore->replaceDefault($data);
         $this->assertSame(200, $response->getStatus());
@@ -250,7 +251,8 @@ class GraphStoreTest extends TestCase
             '{"urn:subject":{"urn:predicate":[{"type":"literal","value":"object"}]}}',
             $client->getRawData()
         );
-        $this->assertSame("application/json", $client->getHeader('Content-Type'));
+        $this->assertSame('application/json', $client->getHeader('Content-Type'));
+
         return true;
     }
 
@@ -262,9 +264,9 @@ class GraphStoreTest extends TestCase
             'PUT',
             '/data/?graph=http%3A%2F%2Ffoo.com%2Fbar.rdf',
             'OK',
-            array('callback' => array($this, 'checkJsonRequest'))
+            ['callback' => [$this, 'checkJsonRequest']]
         );
-        $response = $this->graphStore->replace($graph, "http://foo.com/bar.rdf", 'json');
+        $response = $this->graphStore->replace($graph, 'http://foo.com/bar.rdf', 'json');
         $this->assertSame(200, $response->getStatus());
     }
 
@@ -275,7 +277,7 @@ class GraphStoreTest extends TestCase
             'PUT',
             '/data/existing.rdf',
             'Internal Server Error',
-            array('status' => 500)
+            ['status' => 500]
         );
         $this->setExpectedException(
             'EasyRdf\Exception',

--- a/test/EasyRdf/GraphTest.php
+++ b/test/EasyRdf/GraphTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -38,7 +39,7 @@ namespace EasyRdf;
 
 use EasyRdf\Http\MockClient;
 
-require_once dirname(__DIR__).DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(__DIR__).\DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class MockRdfParser
 {
@@ -49,6 +50,7 @@ class MockRdfParser
             'foaf:name',
             'Joseph Bloggs'
         );
+
         return true;
     }
 }
@@ -57,7 +59,7 @@ class MockRdfSerialiser
 {
     public function serialise($graph, $format = null)
     {
-        return "<rdf></rdf>";
+        return '<rdf></rdf>';
     }
 }
 
@@ -129,7 +131,7 @@ class GraphTest extends TestCase
         $this->assertClass('EasyRdf\Literal', $name);
         $this->assertSame('Joe Bloggs', $name->getValue());
         $this->assertSame('en', $name->getLang());
-        $this->assertSame(null, $name->getDatatype());
+        $this->assertNull($name->getDatatype());
     }
 
     /**
@@ -161,7 +163,7 @@ class GraphTest extends TestCase
         $this->assertClass('EasyRdf\Literal', $name);
         $this->assertSame('Joe Bloggs', $name->getValue());
         $this->assertSame('en', $name->getLang());
-        $this->assertSame(null, $name->getDatatype());
+        $this->assertNull($name->getDatatype());
     }
 
     public function testParseFile()
@@ -174,15 +176,15 @@ class GraphTest extends TestCase
         $this->assertClass('EasyRdf\Literal', $name);
         $this->assertSame('Joe Bloggs', $name->getValue());
         $this->assertSame('en', $name->getLang());
-        $this->assertSame(null, $name->getDatatype());
+        $this->assertNull($name->getDatatype());
     }
 
-	public function testParseLargeFile()
-	{
-		$graph = new Graph();
-		$count = $graph->parseFile(fixturePath('stw.rdf'));
-		$this->assertSame(109340, $count);
-	}
+    public function testParseLargeFile()
+    {
+        $graph = new Graph();
+        $count = $graph->parseFile(fixturePath('stw.rdf'));
+        $this->assertSame(109340, $count);
+    }
 
     public function testParseFileRelativeUri()
     {
@@ -256,7 +258,7 @@ class GraphTest extends TestCase
             '$resource should be either IRI, blank-node identifier or EasyRdf\Resource'
         );
         $graph = new Graph();
-        $graph->load(array());
+        $graph->load([]);
     }
 
     public function testLoadUnknownFormat()
@@ -276,7 +278,7 @@ class GraphTest extends TestCase
             'GET',
             'http://www.example.com/404',
             'Not Found',
-            array('status' => 404)
+            ['status' => 404]
         );
         $this->setExpectedException(
             'EasyRdf\Exception',
@@ -303,7 +305,7 @@ class GraphTest extends TestCase
             'GET',
             'http://www.example.com/',
             readFixture('foaf.json'),
-            array('headers' => array('Content-Type' => 'application/json'))
+            ['headers' => ['Content-Type' => 'application/json']]
         );
         $graph = new Graph('http://www.example.com/');
         $this->assertSame(14, $graph->load());
@@ -319,7 +321,7 @@ class GraphTest extends TestCase
             'GET',
             'http://www.example.com/',
             readFixture('foaf.nt'),
-            array('headers' => array('Content-Type' => 'text/plain; charset=utf8'))
+            ['headers' => ['Content-Type' => 'text/plain; charset=utf8']]
         );
         $graph = new Graph('http://www.example.com/');
         $this->assertSame(14, $graph->load());
@@ -390,7 +392,7 @@ class GraphTest extends TestCase
 
     public function testNewAndLoadError()
     {
-        $this->client->addMockOnce('GET', 'http://www.example.com/missing', 'Error text', array('status' => 404));
+        $this->client->addMockOnce('GET', 'http://www.example.com/missing', 'Error text', ['status' => 404]);
 
         try {
             Graph::newAndLoad('http://www.example.com/missing', 'turtle');
@@ -497,7 +499,7 @@ class GraphTest extends TestCase
             '$resource should be either IRI, blank-node identifier or EasyRdf\Resource'
         );
         $graph = new Graph();
-        $graph->resource(array());
+        $graph->resource([]);
     }
 
     public function testResourceWithType()
@@ -527,7 +529,7 @@ class GraphTest extends TestCase
         $graph = new Graph();
         $resource = $graph->resource(
             'http://www.foo.com/bar',
-            array('rdf:Type1', 'rdf:Type2')
+            ['rdf:Type1', 'rdf:Type2']
         );
 
         $types = $resource->types();
@@ -541,14 +543,14 @@ class GraphTest extends TestCase
         $data = readFixture('foaf.json');
         $graph = new Graph('http://example.com/joe/foaf', $data);
         $resources = $graph->resources();
-        $this->assertTrue(is_array($resources));
+        $this->assertTrue(\is_array($resources));
         $this->assertClass('EasyRdf\Resource', $resources['_:genid1']);
 
         $urls = array_keys($resources);
         sort($urls);
 
         $this->assertSame(
-            array(
+            [
                 '_:genid1',
                 'http://www.example.com/joe#me',
                 'http://www.example.com/joe/',
@@ -556,8 +558,8 @@ class GraphTest extends TestCase
                 'http://www.example.com/project',
                 'http://xmlns.com/foaf/0.1/Person',
                 'http://xmlns.com/foaf/0.1/PersonalProfileDocument',
-                'http://xmlns.com/foaf/0.1/Project'
-            ),
+                'http://xmlns.com/foaf/0.1/Project',
+            ],
             $urls
         );
     }
@@ -900,9 +902,9 @@ class GraphTest extends TestCase
         $all = $this->graph->all($this->uri, 'rdf:test|rdf:foobar');
         $this->assertCount(3, $all);
 
-        $strings = array_map("strval", $all);
+        $strings = array_map('strval', $all);
         $this->assertSame(
-            array('Test A', 'Test B', 'Test C'),
+            ['Test A', 'Test B', 'Test C'],
             $strings
         );
     }
@@ -914,7 +916,7 @@ class GraphTest extends TestCase
         $this->graph->addLiteral('http://example.com/', 'rdfs:label', 'My Homepage');
         $this->graph->addLiteral('http://literal.com/', 'rdfs:label', 'Not My Homepage');
         $this->assertEquals(
-            array(new Literal('My Homepage')),
+            [new Literal('My Homepage')],
             $this->graph->all('http://example.com/person', 'foaf:homepage/rdfs:label')
         );
     }
@@ -922,7 +924,7 @@ class GraphTest extends TestCase
     public function testAllPropertyPathNoMatch()
     {
         $this->assertEquals(
-            array(),
+            [],
             $this->graph->all('http://example.com/person', 'foaf:homepage/rdfs:label')
         );
     }
@@ -930,7 +932,7 @@ class GraphTest extends TestCase
     public function testAllNonExistantResource()
     {
         $this->assertSame(
-            array(),
+            [],
             $this->graph->all('foo:bar', 'foo:bar')
         );
     }
@@ -938,7 +940,7 @@ class GraphTest extends TestCase
     public function testAllNonExistantProperty()
     {
         $this->assertSame(
-            array(),
+            [],
             $this->graph->all($this->uri, 'foo:bar')
         );
     }
@@ -967,7 +969,7 @@ class GraphTest extends TestCase
             'InvalidArgumentException',
             '$propertyPath should be a string or EasyRdf\Resource and cannot be null'
         );
-        $this->graph->all($this->uri, array());
+        $this->graph->all($this->uri, []);
     }
 
     public function testAllOfType()
@@ -975,7 +977,7 @@ class GraphTest extends TestCase
         $data = readFixture('foaf.json');
         $graph = new Graph('http://example.com/joe/foaf', $data);
         $resources = $graph->allOfType('foaf:Person');
-        $this->assertTrue(is_array($resources));
+        $this->assertTrue(\is_array($resources));
         $this->assertCount(1, $resources);
         $this->assertSame(
             'http://www.example.com/joe#me',
@@ -987,7 +989,7 @@ class GraphTest extends TestCase
     {
         $graph = new Graph();
         $resources = $graph->allOfType('unknown:type');
-        $this->assertTrue(is_array($resources));
+        $this->assertTrue(\is_array($resources));
         $this->assertCount(0, $resources);
     }
 
@@ -1002,7 +1004,7 @@ class GraphTest extends TestCase
     public function testAllLiteralsEmpty()
     {
         $all = $this->graph->allLiterals($this->uri, 'rdf:type');
-        $this->assertTrue(is_array($all));
+        $this->assertTrue(\is_array($all));
         $this->assertCount(0, $all);
     }
 
@@ -1139,7 +1141,7 @@ class GraphTest extends TestCase
             'InvalidArgumentException',
             '$propertyPath should be a string or EasyRdf\Resource and cannot be null'
         );
-        $this->graph->join($this->uri, array(), 'Test C');
+        $this->graph->join($this->uri, [], 'Test C');
     }
 
     public function testAdd()
@@ -1175,12 +1177,12 @@ class GraphTest extends TestCase
         $title = $this->graph->get($this->uri, 'dc:title');
         $this->assertSame('English Title', $title->getValue());
         $this->assertSame('en', $title->getLang());
-        $this->assertSame(null, $title->getDataType());
+        $this->assertNull($title->getDataType());
     }
 
     public function testAddMultipleLiterals()
     {
-        $count = $this->graph->addLiteral($this->uri, 'rdf:test', array('Test C', 'Test D'));
+        $count = $this->graph->addLiteral($this->uri, 'rdf:test', ['Test C', 'Test D']);
         $this->assertSame(2, $count);
         $all = $this->graph->all($this->uri, 'rdf:test');
         $this->assertCount(4, $all);
@@ -1215,20 +1217,20 @@ class GraphTest extends TestCase
 
     public function testAddDateTime()
     {
-        $dt = new \DateTime("Fri 25 Jan 2013 19:43:19 GMT");
+        $dt = new \DateTime('Fri 25 Jan 2013 19:43:19 GMT');
         $count = $this->graph->add($this->uri, 'rdf:test2', $dt);
         $this->assertSame(1, $count);
 
         $literal = $this->graph->get($this->uri, 'rdf:test2');
         $this->assertClass('EasyRdf\Literal\DateTime', $literal);
         $this->assertStringEquals('2013-01-25T19:43:19Z', $literal);
-        $this->assertSame(null, $literal->getLang());
+        $this->assertNull($literal->getLang());
         $this->assertSame('xsd:dateTime', $literal->getDataType());
     }
 
     public function testAddLiteralDateTime()
     {
-        $dt = new \DateTime("Fri 25 Jan 2013 19:43:19 GMT");
+        $dt = new \DateTime('Fri 25 Jan 2013 19:43:19 GMT');
         $this->graph->addLiteral($this->uri, 'rdf:test2', $dt);
         $this->assertStringEquals(
             '2013-01-25T19:43:19Z',
@@ -1270,7 +1272,7 @@ class GraphTest extends TestCase
             'InvalidArgumentException',
             '$property should be a string or EasyRdf\Resource and cannot be null'
         );
-        $this->graph->add($this->uri, array(), 'Test C');
+        $this->graph->add($this->uri, [], 'Test C');
     }
 
     public function testAddInvalidObject()
@@ -1293,7 +1295,7 @@ class GraphTest extends TestCase
             'InvalidArgumentException',
             '$value is missing a \'type\' key'
         );
-        $this->graph->add($this->uri, 'rdf:foo', array('value' => 'bar'));
+        $this->graph->add($this->uri, 'rdf:foo', ['value' => 'bar']);
     }
 
     public function testAddMissingArrayValue()
@@ -1302,7 +1304,7 @@ class GraphTest extends TestCase
             'InvalidArgumentException',
             '$value is missing a \'value\' key'
         );
-        $this->graph->add($this->uri, 'rdf:foo', array('type' => 'literal'));
+        $this->graph->add($this->uri, 'rdf:foo', ['type' => 'literal']);
     }
 
     public function testAddInvalidArrayType()
@@ -1311,7 +1313,7 @@ class GraphTest extends TestCase
             'InvalidArgumentException',
             '$value does not have a valid type (foo)'
         );
-        $this->graph->add($this->uri, 'rdf:foo', array('type' => 'foo', 'value' => 'bar'));
+        $this->graph->add($this->uri, 'rdf:foo', ['type' => 'foo', 'value' => 'bar']);
     }
 
     public function testAddArrayWithLangAndDatatype()
@@ -1323,12 +1325,12 @@ class GraphTest extends TestCase
         $this->graph->add(
             $this->uri,
             'rdf:foo',
-            array(
+            [
                 'type' => 'literal',
                 'value' => 'Rat',
                 'lang' => 'en',
-                'datatype' => 'http://www.w3.org/2001/XMLSchema#string'
-            )
+                'datatype' => 'http://www.w3.org/2001/XMLSchema#string',
+            ]
         );
     }
 
@@ -1372,11 +1374,11 @@ class GraphTest extends TestCase
 
         $graph->delete('http://www.example.com/joe#me', 'rdf:test', 'Test A');
         $result = $graph->get('http://www.example.com/joe#me', 'rdf:test');
-        $this->assertStringEquals("Test B", $result);
+        $this->assertStringEquals('Test B', $result);
 
         $graph->delete('http://www.example.com/joe#me', 'rdf:test', 'Test B');
         $result = $graph->get('http://www.example.com/joe#me', 'rdf:test');
-        $this->assertStringEquals("Test C", $result);
+        $this->assertStringEquals('Test C', $result);
 
         $graph->delete('http://www.example.com/joe#me', 'rdf:test');
         $result = $graph->get('http://www.example.com/joe#me', 'rdf:test');
@@ -1431,7 +1433,7 @@ class GraphTest extends TestCase
         $this->assertCount(1, $all);
         $this->assertStringEquals($homepage, $all[0]);
 
-        # Check inverse too
+        // Check inverse too
         $all = $this->graph->all($homepage, '^foaf:homepage');
         $this->assertCount(1, $all);
         $this->assertStringEquals('http://example.com/#me', $all[0]);
@@ -1461,14 +1463,14 @@ class GraphTest extends TestCase
     {
         $this->assertStringEquals('Test A', $this->graph->get($this->uri, 'rdf:test'));
         $this->assertSame(2, $this->graph->delete($this->uri, 'rdf:test'));
-        $this->assertSame(array(), $this->graph->all($this->uri, 'rdf:test'));
+        $this->assertSame([], $this->graph->all($this->uri, 'rdf:test'));
     }
 
     public function testDeleteWithPropertyUri()
     {
         $this->assertStringEquals('Test A', $this->graph->get($this->uri, 'rdf:test'));
         $this->assertSame(2, $this->graph->delete($this->uri, '<http://www.w3.org/1999/02/22-rdf-syntax-ns#test>'));
-        $this->assertSame(array(), $this->graph->all($this->uri, 'rdf:test'));
+        $this->assertSame([], $this->graph->all($this->uri, 'rdf:test'));
     }
 
     public function testDeleteWithPropertyResource()
@@ -1476,7 +1478,7 @@ class GraphTest extends TestCase
         $prop = $this->graph->resource('http://www.w3.org/1999/02/22-rdf-syntax-ns#test');
         $this->assertStringEquals('Test A', $this->graph->get($this->uri, 'rdf:test'));
         $this->assertSame(2, $this->graph->delete($this->uri, $prop));
-        $this->assertSame(array(), $this->graph->all($this->uri, 'rdf:test'));
+        $this->assertSame([], $this->graph->all($this->uri, 'rdf:test'));
     }
 
     public function testDeleteWithUri()
@@ -1489,7 +1491,7 @@ class GraphTest extends TestCase
                 'http://www.w3.org/1999/02/22-rdf-syntax-ns#test'
             )
         );
-        $this->assertSame(array(), $this->graph->all($this->uri, 'rdf:test'));
+        $this->assertSame([], $this->graph->all($this->uri, 'rdf:test'));
     }
 
     public function testDeleteNonExistantProperty()
@@ -1521,7 +1523,7 @@ class GraphTest extends TestCase
             'InvalidArgumentException',
             '$property should be a string or EasyRdf\Resource and cannot be null'
         );
-        $this->graph->delete($this->uri, array());
+        $this->graph->delete($this->uri, []);
     }
 
     public function testDeletePropertyResource()
@@ -1563,7 +1565,7 @@ class GraphTest extends TestCase
     public function testDeleteLiteralArrayValue()
     {
         // Keys are deliberately in the wrong order
-        $testa = array('value' => 'Test A', 'type' => 'literal');
+        $testa = ['value' => 'Test A', 'type' => 'literal'];
         $this->assertSame(2, $this->graph->countValues($this->uri, 'rdf:test'));
         $this->assertSame(1, $this->graph->delete($this->uri, 'rdf:test', $testa));
         $this->assertSame(1, $this->graph->countValues($this->uri, 'rdf:test'));
@@ -1572,7 +1574,7 @@ class GraphTest extends TestCase
     public function testDeleteResourceArrayValue()
     {
         // Keys are deliberately in the wrong order
-        $res = array('value' => 'http://www.example.com/', 'type' => 'uri');
+        $res = ['value' => 'http://www.example.com/', 'type' => 'uri'];
         $this->graph->addResource($this->uri, 'foaf:homepage', 'http://www.example.com/');
         $this->assertSame(1, $this->graph->countValues($this->uri, 'foaf:homepage'));
         $this->assertSame(1, $this->graph->delete($this->uri, 'foaf:homepage', $res));
@@ -1651,16 +1653,16 @@ class GraphTest extends TestCase
     {
         Format::registerSerialiser('mock', 'EasyRdf\MockRdfSerialiser');
         $graph = new Graph();
-        $this->assertSame("<rdf></rdf>", $graph->serialise('mock'));
+        $this->assertSame('<rdf></rdf>', $graph->serialise('mock'));
     }
 
     public function testSerialiseByMime()
     {
         Format::registerSerialiser('mock', 'EasyRdf\MockRdfSerialiser');
-        Format::register('mock', 'Mock', null, array('mock/mime' => 1.0));
+        Format::register('mock', 'Mock', null, ['mock/mime' => 1.0]);
         $graph = new Graph();
         $this->assertSame(
-            "<rdf></rdf>",
+            '<rdf></rdf>',
             $graph->serialise('mock/mime')
         );
     }
@@ -1670,7 +1672,7 @@ class GraphTest extends TestCase
         $format = Format::register('mock', 'Mock Format');
         $format->setSerialiserClass('EasyRdf\MockRdfSerialiser');
         $graph = new Graph();
-        $this->assertSame("<rdf></rdf>", $graph->serialise($format));
+        $this->assertSame('<rdf></rdf>', $graph->serialise($format));
     }
 
     public function testIsEmpty()
@@ -1697,7 +1699,7 @@ class GraphTest extends TestCase
     public function testProperties()
     {
         $this->assertSame(
-            array('rdf:type', 'rdf:test'),
+            ['rdf:type', 'rdf:test'],
             $this->graph->properties($this->uri)
         );
     }
@@ -1705,7 +1707,7 @@ class GraphTest extends TestCase
     public function testPropertiesForNonExistantResource()
     {
         $this->assertSame(
-            array(),
+            [],
             $this->graph->properties('http://doesnotexist.com/')
         );
     }
@@ -1713,10 +1715,10 @@ class GraphTest extends TestCase
     public function testPropertyUris()
     {
         $this->assertSame(
-            array(
+            [
                 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
-                'http://www.w3.org/1999/02/22-rdf-syntax-ns#test'
-            ),
+                'http://www.w3.org/1999/02/22-rdf-syntax-ns#test',
+            ],
             $this->graph->propertyUris($this->uri)
         );
     }
@@ -1724,7 +1726,7 @@ class GraphTest extends TestCase
     public function testNoReversePropertyUris()
     {
         $this->assertSame(
-            array(),
+            [],
             $this->graph->reversePropertyUris('foaf:Document')
         );
     }
@@ -1732,9 +1734,9 @@ class GraphTest extends TestCase
     public function testReversePropertyUris()
     {
         $this->assertSame(
-            array(
-                'http://www.w3.org/1999/02/22-rdf-syntax-ns#type'
-            ),
+            [
+                'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
+            ],
             $this->graph->reversePropertyUris('foaf:Person')
         );
     }
@@ -1742,7 +1744,7 @@ class GraphTest extends TestCase
     public function testPropertyUrisForNonExistantResource()
     {
         $this->assertSame(
-            array(),
+            [],
             $this->graph->propertyUris('http://doesnotexist.com/')
         );
     }
@@ -1949,8 +1951,8 @@ class GraphTest extends TestCase
 
     public function testTypesNotLiteral()
     {
-        $this->graph->addResource($this->uri, 'rdf:type', "foaf:Rat");
-        $this->graph->addLiteral($this->uri, 'rdf:type', "Literal");
+        $this->graph->addResource($this->uri, 'rdf:type', 'foaf:Rat');
+        $this->graph->addLiteral($this->uri, 'rdf:type', 'Literal');
         $types = $this->graph->types($this->uri);
         $this->assertCount(2, $types);
         $this->assertStringEquals('foaf:Person', $types[0]);
@@ -2083,27 +2085,27 @@ class GraphTest extends TestCase
     public function testToRdfPhp()
     {
         $this->assertSame(
-            array(
-                'http://example.com/#me' => array(
-                    'http://www.w3.org/1999/02/22-rdf-syntax-ns#type' => array(
-                        array(
+            [
+                'http://example.com/#me' => [
+                    'http://www.w3.org/1999/02/22-rdf-syntax-ns#type' => [
+                        [
                             'type' => 'uri',
-                            'value' => 'http://xmlns.com/foaf/0.1/Person'
-                        )
-                    ),
-                    'http://www.w3.org/1999/02/22-rdf-syntax-ns#test' => array(
-                        array(
+                            'value' => 'http://xmlns.com/foaf/0.1/Person',
+                        ],
+                    ],
+                    'http://www.w3.org/1999/02/22-rdf-syntax-ns#test' => [
+                        [
                             'type' => 'literal',
-                            'value' => 'Test A'
-                        ),
-                        array(
+                            'value' => 'Test A',
+                        ],
+                        [
                             'type' => 'literal',
                             'value' => 'Test B',
-                            'lang' => 'en'
-                        )
-                    )
-                )
-            ),
+                            'lang' => 'en',
+                        ],
+                    ],
+                ],
+            ],
             $this->graph->toRdfPhp()
         );
     }
@@ -2127,8 +2129,7 @@ class GraphTest extends TestCase
     public function testMagicGetNonExistant()
     {
         RdfNamespace::setDefault('rdf');
-        $this->assertSame(
-            null,
+        $this->assertNull(
             $this->graph->foobar
         );
     }

--- a/test/EasyRdf/Http/ClientTest.php
+++ b/test/EasyRdf/Http/ClientTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Http;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -39,8 +40,7 @@ namespace EasyRdf\Http;
 use EasyRdf\Resource;
 use EasyRdf\TestCase;
 
-require_once realpath(dirname(__FILE__) . '/../../') . '/TestHelper.php';
-
+require_once realpath(__DIR__.'/../../').'/TestHelper.php';
 
 class ClientTest extends TestCase
 {
@@ -53,7 +53,6 @@ class ClientTest extends TestCase
 
     /**
      * Set up the test suite before each test
-     *
      */
     public function setUp()
     {
@@ -64,14 +63,13 @@ class ClientTest extends TestCase
     {
         $client = new Client(
             'http://www.example.com/',
-            array('foo' => 'bar')
+            ['foo' => 'bar']
         );
         $this->assertClass('EasyRdf\Http\Client', $client);
     }
 
     /**
      * Test we can SET and GET a URI as string
-     *
      */
     public function testSetGetUriString()
     {
@@ -86,9 +84,9 @@ class ClientTest extends TestCase
 
         $uri = $this->client->getUri(true);
         $this->assertTrue(
-            is_string($uri),
-            'Returned value expected to be a string, ' .
-            gettype($uri) . ' returned'
+            \is_string($uri),
+            'Returned value expected to be a string, '.
+            \gettype($uri).' returned'
         );
         $this->assertSame(
             $uri,
@@ -121,7 +119,6 @@ class ClientTest extends TestCase
 
     /**
      * Test we can SET and GET a URI as object
-     *
      */
     public function testSetGetUriObject()
     {
@@ -135,7 +132,7 @@ class ClientTest extends TestCase
 
     public function testSetConfig()
     {
-        $result = $this->client->setConfig(array('foo' => 'bar'));
+        $result = $this->client->setConfig(['foo' => 'bar']);
         $this->assertClass('EasyRdf\Http\Client', $result);
     }
 
@@ -159,7 +156,6 @@ class ClientTest extends TestCase
 
     /**
      * Test we can get already set headers
-     *
      */
     public function testGetHeader()
     {
@@ -228,7 +224,7 @@ class ClientTest extends TestCase
         $this->client->setParameterGet('key1', 'value1');
         $this->client->setParameterGet('key2', 'value2');
         $this->client->setParameterGet('key1', null);
-        $this->assertSame(null, $this->client->getParameterGet('key1'));
+        $this->assertNull($this->client->getParameterGet('key1'));
         $this->assertSame('value2', $this->client->getParameterGet('key2'));
     }
 
@@ -257,9 +253,9 @@ class ClientTest extends TestCase
         $this->client->setHeaders('Accept-Language', 'en');
         $this->client->resetParameters();
         $this->assertSame('GET', $this->client->getMethod());
-        $this->assertSame(null, $this->client->getRawData());
-        $this->assertSame(null, $this->client->getHeader('Content-Length'));
-        $this->assertSame(null, $this->client->getHeader('Content-Type'));
+        $this->assertNull($this->client->getRawData());
+        $this->assertNull($this->client->getHeader('Content-Length'));
+        $this->assertNull($this->client->getHeader('Content-Type'));
         $this->assertSame('en', $this->client->getHeader('Accept-Language'));
     }
 
@@ -272,9 +268,9 @@ class ClientTest extends TestCase
         $this->client->setHeaders('Accept-Language', 'en');
         $this->client->resetParameters(true);
         $this->assertSame('GET', $this->client->getMethod());
-        $this->assertSame(null, $this->client->getRawData());
-        $this->assertSame(null, $this->client->getHeader('Content-Length'));
-        $this->assertSame(null, $this->client->getHeader('Content-Type'));
-        $this->assertSame(null, $this->client->getHeader('Accept-Language'));
+        $this->assertNull($this->client->getRawData());
+        $this->assertNull($this->client->getHeader('Content-Length'));
+        $this->assertNull($this->client->getHeader('Content-Type'));
+        $this->assertNull($this->client->getHeader('Accept-Language'));
     }
 }

--- a/test/EasyRdf/Http/MockClientTest.php
+++ b/test/EasyRdf/Http/MockClientTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Http;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -38,9 +39,8 @@ namespace EasyRdf\Http;
 
 use EasyRdf\TestCase;
 
-require_once realpath(__DIR__ . '/../../') . '/TestHelper.php';
+require_once realpath(__DIR__.'/../../').'/TestHelper.php';
 require_once __DIR__.'/MockClient.php';
-
 
 class MockClientTest extends TestCase
 {
@@ -55,6 +55,7 @@ class MockClientTest extends TestCase
     protected function get($uri)
     {
         $this->client->setUri($uri);
+
         return $this->client->request('GET');
     }
 
@@ -142,24 +143,24 @@ class MockClientTest extends TestCase
 
     public function testSetStatus()
     {
-        $this->client->addMock('GET', '/test', 'x', array('status' => 404));
+        $this->client->addMock('GET', '/test', 'x', ['status' => 404]);
         $response = $this->get('http://example.com/test');
         $this->assertSame(404, $response->getStatus());
     }
 
     public function testSetHeaders()
     {
-        $h = array('Content-Type' => 'text/html');
-        $this->client->addMock('GET', '/test', 'x', array('headers' => $h));
+        $h = ['Content-Type' => 'text/html'];
+        $this->client->addMock('GET', '/test', 'x', ['headers' => $h]);
         $response = $this->get('http://example.com/test');
         $this->assertSame('text/html', $response->getHeader('Content-Type'));
     }
 
     public function testSetResponse()
     {
-        $response = new Response(234, array('Foo' => 'bar'), 'x');
+        $response = new Response(234, ['Foo' => 'bar'], 'x');
         $this->client->addMock('GET', '/test', $response);
-        $r = $this->get('http://example.com/test', array('throw' => false));
+        $r = $this->get('http://example.com/test', ['throw' => false]);
         $this->assertSame(234, $r->getStatus());
         $this->assertSame('bar', $r->getHeader('Foo'));
         $this->assertSame('x', $r->getBody());
@@ -167,7 +168,7 @@ class MockClientTest extends TestCase
 
     public function testOnce()
     {
-        $this->client->addMock('GET', '/test', '10', array('once' => true));
+        $this->client->addMock('GET', '/test', '10', ['once' => true]);
         $this->client->addMockOnce('GET', '/test', '20');
         $this->client->addMock('GET', '/test', '30');
         $r = $this->get('http://example.com/test');
@@ -200,8 +201,8 @@ class MockClientTest extends TestCase
 
     public function testCallbackWithoutArgs()
     {
-        $alwaysTrue = array('callback' => array($this, 'alwaysTrue'));
-        $alwaysFalse = array('callback' => array($this, 'alwaysFalse'));
+        $alwaysTrue = ['callback' => [$this, 'alwaysTrue']];
+        $alwaysFalse = ['callback' => [$this, 'alwaysFalse']];
 
         $this->client->addMock('GET', '/test1', '10', $alwaysTrue);
         $r = $this->get('http://example.com/test1');
@@ -226,10 +227,10 @@ class MockClientTest extends TestCase
 
     public function testCallbackWithArgs()
     {
-        $echoTrue = array('callback' => array($this, 'echoValue'),
-                          'callbackArgs' => array(true));
-        $echoFalse = array('callback' => array($this, 'echoValue'),
-                           'callbackArgs' => array(false));
+        $echoTrue = ['callback' => [$this, 'echoValue'],
+                          'callbackArgs' => [true], ];
+        $echoFalse = ['callback' => [$this, 'echoValue'],
+                           'callbackArgs' => [false], ];
 
         $this->client->addMock('GET', '/test1', '10', $echoTrue);
         $r = $this->get('http://example.com/test1');
@@ -249,7 +250,7 @@ class MockClientTest extends TestCase
 
     public function testCallbackWithMockHttp()
     {
-        $isMockHttp = array('callback' => array($this, 'isMockHttp'));
+        $isMockHttp = ['callback' => [$this, 'isMockHttp']];
         $this->client->addMock('GET', '/test1', '10', $isMockHttp);
         $r = $this->get('http://example.com/test1');
         $this->assertSame('10', $r->getBody());
@@ -257,7 +258,7 @@ class MockClientTest extends TestCase
 
     public function isMockHttp($value)
     {
-        return ($value instanceof MockClient);
+        return $value instanceof MockClient;
     }
 
     public function testGuessJsonContentType()

--- a/test/EasyRdf/Http/ResponseTest.php
+++ b/test/EasyRdf/Http/ResponseTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Http;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -36,12 +37,12 @@ namespace EasyRdf\Http;
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
 
-/**
+/*
  * Test helper
  */
 use EasyRdf\TestCase;
 
-require_once realpath(__DIR__ . '/../../') . '/TestHelper.php';
+require_once realpath(__DIR__.'/../../').'/TestHelper.php';
 
 class ResponseTest extends TestCase
 {
@@ -125,7 +126,7 @@ class ResponseTest extends TestCase
      * and trailer. Unfortunately some buggy servers (read: IIS) send those and
      * we need to support them.
      *
-     * @link http://framework.zend.com/issues/browse/ZF-6040
+     * @see http://framework.zend.com/issues/browse/ZF-6040
      */
     public function testNonStandardDeflateResponseZF6040()
     {
@@ -144,7 +145,7 @@ class ResponseTest extends TestCase
             readFixture('http_response_200_chunked')
         );
         $this->assertSame(
-            "Hello World",
+            'Hello World',
             $response->getBody()
         );
     }
@@ -288,12 +289,11 @@ class ResponseTest extends TestCase
             'Content-type header is not as expected'
         );
         $this->assertSame(
-            array('foo','bar'),
+            ['foo', 'bar'],
             $response->getHeader('X-Multiple'),
             'Header with multiple values is not as expected'
         );
     }
-
 
     public function testAsString()
     {
@@ -307,7 +307,7 @@ class ResponseTest extends TestCase
         );
         $this->assertSame(
             strtolower($responseStr),
-            strtolower((string)$response),
+            strtolower((string) $response),
             'Response convertion to string does not match original string'
         );
     }

--- a/test/EasyRdf/HttpTest.php
+++ b/test/EasyRdf/HttpTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -38,7 +39,7 @@ namespace EasyRdf;
 
 use EasyRdf\Http\MockClient;
 
-require_once dirname(__DIR__).DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(__DIR__).\DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class HttpTest extends TestCase
 {

--- a/test/EasyRdf/IsomorphicTest.php
+++ b/test/EasyRdf/IsomorphicTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EasyRdf;
 
 /**
@@ -31,12 +32,10 @@ namespace EasyRdf;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
-
-require_once dirname(__DIR__).DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(__DIR__).\DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class IsomorphicTest extends TestCase
 {
@@ -91,7 +90,7 @@ class IsomorphicTest extends TestCase
 
     public function testGood05()
     {
-        $this->markTestIncomplete("FIXME: Three triple chain with renamed bnodes is not implemented yet");
+        $this->markTestIncomplete('FIXME: Three triple chain with renamed bnodes is not implemented yet');
         // Three triple chain with renamed bnodes
         $this->checkTestCase('good-05');
     }

--- a/test/EasyRdf/Literal/BooleanTest.php
+++ b/test/EasyRdf/Literal/BooleanTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Literal;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -38,8 +39,7 @@ namespace EasyRdf\Literal;
 
 use EasyRdf\TestCase;
 
-require_once realpath(__DIR__ . '/../../') . '/TestHelper.php';
-
+require_once realpath(__DIR__.'/../../').'/TestHelper.php';
 
 class BooleanTest extends TestCase
 {
@@ -48,8 +48,8 @@ class BooleanTest extends TestCase
         $literal = new Boolean('true');
         $this->assertStringEquals('true', $literal);
         $this->assertInternalType('bool', $literal->getValue());
-        $this->assertSame(true, $literal->getValue());
-        $this->assertSame(null, $literal->getLang());
+        $this->assertTrue($literal->getValue());
+        $this->assertNull($literal->getLang());
         $this->assertSame('xsd:boolean', $literal->getDatatype());
     }
 
@@ -58,8 +58,8 @@ class BooleanTest extends TestCase
         $literal = new Boolean('false');
         $this->assertStringEquals('false', $literal);
         $this->assertInternalType('bool', $literal->getValue());
-        $this->assertSame(false, $literal->getValue());
-        $this->assertSame(null, $literal->getLang());
+        $this->assertFalse($literal->getValue());
+        $this->assertNull($literal->getLang());
         $this->assertSame('xsd:boolean', $literal->getDatatype());
     }
 
@@ -68,8 +68,8 @@ class BooleanTest extends TestCase
         $literal = new Boolean('1');
         $this->assertStringEquals('1', $literal);
         $this->assertInternalType('bool', $literal->getValue());
-        $this->assertSame(true, $literal->getValue());
-        $this->assertSame(null, $literal->getLang());
+        $this->assertTrue($literal->getValue());
+        $this->assertNull($literal->getLang());
         $this->assertSame('xsd:boolean', $literal->getDatatype());
     }
 
@@ -78,8 +78,8 @@ class BooleanTest extends TestCase
         $literal = new Boolean('0');
         $this->assertStringEquals('0', $literal);
         $this->assertInternalType('bool', $literal->getValue());
-        $this->assertSame(false, $literal->getValue());
-        $this->assertSame(null, $literal->getLang());
+        $this->assertFalse($literal->getValue());
+        $this->assertNull($literal->getLang());
         $this->assertSame('xsd:boolean', $literal->getDatatype());
     }
 
@@ -88,8 +88,8 @@ class BooleanTest extends TestCase
         $literal = new Boolean(true);
         $this->assertStringEquals('true', $literal);
         $this->assertInternalType('bool', $literal->getValue());
-        $this->assertSame(true, $literal->getValue());
-        $this->assertSame(null, $literal->getLang());
+        $this->assertTrue($literal->getValue());
+        $this->assertNull($literal->getLang());
         $this->assertSame('xsd:boolean', $literal->getDatatype());
     }
 
@@ -98,8 +98,8 @@ class BooleanTest extends TestCase
         $literal = new Boolean(false);
         $this->assertStringEquals('false', $literal);
         $this->assertInternalType('bool', $literal->getValue());
-        $this->assertSame(false, $literal->getValue());
-        $this->assertSame(null, $literal->getLang());
+        $this->assertFalse($literal->getValue());
+        $this->assertNull($literal->getLang());
         $this->assertSame('xsd:boolean', $literal->getDatatype());
     }
 
@@ -108,8 +108,8 @@ class BooleanTest extends TestCase
         $literal = new Boolean(1);
         $this->assertStringEquals('true', $literal);
         $this->assertInternalType('bool', $literal->getValue());
-        $this->assertSame(true, $literal->getValue());
-        $this->assertSame(null, $literal->getLang());
+        $this->assertTrue($literal->getValue());
+        $this->assertNull($literal->getLang());
         $this->assertSame('xsd:boolean', $literal->getDatatype());
     }
 
@@ -118,26 +118,26 @@ class BooleanTest extends TestCase
         $literal = new Boolean(0);
         $this->assertStringEquals('false', $literal);
         $this->assertInternalType('bool', $literal->getValue());
-        $this->assertSame(false, $literal->getValue());
-        $this->assertSame(null, $literal->getLang());
+        $this->assertFalse($literal->getValue());
+        $this->assertNull($literal->getLang());
         $this->assertSame('xsd:boolean', $literal->getDatatype());
     }
 
     public function testIsTrue()
     {
         $true = new Boolean(true);
-        $this->assertSame(true, $true->isTrue());
+        $this->assertTrue($true->isTrue());
 
         $false = new Boolean(false);
-        $this->assertSame(false, $false->isTrue());
+        $this->assertFalse($false->isTrue());
     }
 
     public function testIsFalse()
     {
         $false = new Boolean(false);
-        $this->assertSame(true, $false->isFalse());
+        $this->assertTrue($false->isFalse());
 
         $true = new Boolean(true);
-        $this->assertSame(false, $true->isFalse());
+        $this->assertFalse($true->isFalse());
     }
 }

--- a/test/EasyRdf/Literal/DateTest.php
+++ b/test/EasyRdf/Literal/DateTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Literal;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -38,8 +39,7 @@ namespace EasyRdf\Literal;
 
 use EasyRdf\TestCase;
 
-require_once realpath(__DIR__ . '/../../') . '/TestHelper.php';
-
+require_once realpath(__DIR__.'/../../').'/TestHelper.php';
 
 class DateTest extends TestCase
 {
@@ -48,7 +48,7 @@ class DateTest extends TestCase
         $literal = new Date('2011-08-05Z');
         $this->assertStringEquals('2011-08-05Z', $literal);
         $this->assertClass('DateTime', $literal->getValue());
-        $this->assertSame(null, $literal->getLang());
+        $this->assertNull($literal->getLang());
         $this->assertSame('xsd:date', $literal->getDatatype());
     }
 
@@ -59,7 +59,7 @@ class DateTest extends TestCase
         $this->assertStringEquals('2011-07-18', $literal);
         $this->assertClass('DateTime', $literal->getValue());
         $this->assertEquals($dt, $literal->getValue());
-        $this->assertSame(null, $literal->getLang());
+        $this->assertNull($literal->getLang());
         $this->assertSame('xsd:date', $literal->getDatatype());
     }
 
@@ -70,7 +70,7 @@ class DateTest extends TestCase
         $today = new \DateTime('today');
         $literal = new Date();
         $this->assertEquals($today, $literal->getValue());
-        $this->assertRegExp('|^\d{4}-\d{2}-\d{2}$|', strval($literal));
+        $this->assertRegExp('|^\d{4}-\d{2}-\d{2}$|', (string) $literal);
     }
 
     public function testParse()
@@ -78,7 +78,7 @@ class DateTest extends TestCase
         $literal = Date::parse('5th August 2011');
         $this->assertStringEquals('2011-08-05', $literal);
         $this->assertClass('DateTime', $literal->getValue());
-        $this->assertSame(null, $literal->getLang());
+        $this->assertNull($literal->getLang());
         $this->assertSame('xsd:date', $literal->getDatatype());
     }
 

--- a/test/EasyRdf/Literal/DateTimeTest.php
+++ b/test/EasyRdf/Literal/DateTimeTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Literal;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -38,8 +39,7 @@ namespace EasyRdf\Literal;
 
 use EasyRdf\TestCase;
 
-require_once realpath(__DIR__ . '/../../') . '/TestHelper.php';
-
+require_once realpath(__DIR__.'/../../').'/TestHelper.php';
 
 class DateTimeTest extends TestCase
 {
@@ -51,7 +51,7 @@ class DateTimeTest extends TestCase
         $literal = new DateTime('2011-07-18T18:45:43Z');
         $this->assertStringEquals('2011-07-18T18:45:43Z', $literal);
         $this->assertClass('DateTime', $literal->getValue());
-        $this->assertSame(null, $literal->getLang());
+        $this->assertNull($literal->getLang());
         $this->assertSame('xsd:dateTime', $literal->getDatatype());
     }
 
@@ -59,8 +59,8 @@ class DateTimeTest extends TestCase
     {
         $now = strtotime('now');
         $literal = new DateTime();
-        $check = strtotime(strval($literal));
-        $this->assertLessThan(2, $check-$now);
+        $check = strtotime((string) $literal);
+        $this->assertLessThan(2, $check - $now);
     }
 
     public function testConstructFromDateTimeBST()
@@ -70,7 +70,7 @@ class DateTimeTest extends TestCase
         $this->assertStringEquals('2010-09-08T07:06:05+01:00', $literal);
         $this->assertClass('DateTime', $literal->getValue());
         $this->assertEquals($dt, $literal->getValue());
-        $this->assertSame(null, $literal->getLang());
+        $this->assertNull($literal->getLang());
         $this->assertSame('xsd:dateTime', $literal->getDatatype());
     }
 
@@ -81,7 +81,7 @@ class DateTimeTest extends TestCase
         $this->assertStringEquals('2010-09-08T07:06:05Z', $literal);
         $this->assertClass('DateTime', $literal->getValue());
         $this->assertEquals($dt, $literal->getValue());
-        $this->assertSame(null, $literal->getLang());
+        $this->assertNull($literal->getLang());
         $this->assertSame('xsd:dateTime', $literal->getDatatype());
     }
 
@@ -90,7 +90,7 @@ class DateTimeTest extends TestCase
         $literal = DateTime::parse('Mon 18 Jul 2011 18:45:43 UTC');
         $this->assertStringEquals('2011-07-18T18:45:43Z', $literal);
         $this->assertClass('DateTime', $literal->getValue());
-        $this->assertSame(null, $literal->getLang());
+        $this->assertNull($literal->getLang());
         $this->assertSame('xsd:dateTime', $literal->getDatatype());
     }
 
@@ -99,11 +99,9 @@ class DateTimeTest extends TestCase
         $literal = DateTime::parse('Mon 18 Jul 2011 18:45:43 BST');
         $this->assertStringEquals('2011-07-18T18:45:43+01:00', $literal);
         $this->assertClass('DateTime', $literal->getValue());
-        $this->assertSame(null, $literal->getLang());
+        $this->assertNull($literal->getLang());
         $this->assertSame('xsd:dateTime', $literal->getDatatype());
     }
-
-
 
     public function setUp()
     {

--- a/test/EasyRdf/Literal/DecimalTest.php
+++ b/test/EasyRdf/Literal/DecimalTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Literal;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -38,8 +39,7 @@ namespace EasyRdf\Literal;
 
 use EasyRdf\TestCase;
 
-require_once realpath(__DIR__ . '/../../') . '/TestHelper.php';
-
+require_once realpath(__DIR__.'/../../').'/TestHelper.php';
 
 class DecimalTest extends TestCase
 {
@@ -48,7 +48,7 @@ class DecimalTest extends TestCase
         $literal = new Decimal(1.5);
         $this->assertInternalType('string', $literal->getValue());
         $this->assertSame('1.5', $literal->getValue());
-        $this->assertSame(null, $literal->getLang());
+        $this->assertNull($literal->getLang());
         $this->assertSame('xsd:decimal', $literal->getDatatype());
     }
 
@@ -62,7 +62,7 @@ class DecimalTest extends TestCase
             $literal = new Decimal(1.5);
             $this->assertInternalType('string', $literal->getValue());
             $this->assertSame('1.5', $literal->getValue());
-            $this->assertSame(null, $literal->getLang());
+            $this->assertNull($literal->getLang());
             $this->assertSame('xsd:decimal', $literal->getDatatype());
 
             setlocale(LC_NUMERIC, $current_locale);
@@ -77,18 +77,18 @@ class DecimalTest extends TestCase
         $literal = new Decimal('100.00');
         $this->assertInternalType('string', $literal->getValue());
         $this->assertSame('100.0', $literal->getValue());
-        $this->assertSame(null, $literal->getLang());
+        $this->assertNull($literal->getLang());
         $this->assertSame('xsd:decimal', $literal->getDatatype());
     }
 
     public function testValidStrings()
     {
-        $valid_strings = array(
+        $valid_strings = [
             // examples taken from http://www.w3.org/TR/xmlschema-2/#decimal
-            "-1.23", "12678967.543233", "+100000.00", "210",
+            '-1.23', '12678967.543233', '+100000.00', '210',
             // examples taken from http://www.schemacentral.com/sc/xsd/t-xsd_decimal.html
-            "3.0", "-3.0", "+3.5", "3", ".3", "3.", "0", "-.3", "0003.", "3.000"
-        );
+            '3.0', '-3.0', '+3.5', '3', '.3', '3.', '0', '-.3', '0003.', '3.000',
+        ];
         foreach ($valid_strings as $literal) {
             new Decimal($literal);
         }
@@ -98,22 +98,22 @@ class DecimalTest extends TestCase
 
     public function testCanonicalisation()
     {
-        $pairs = array(
-            "-1.23" => "-1.23",
-            "12678967.543233" => "12678967.543233",
-            "+100000.00" => "100000.0",
-            "210" => "210.0",
-            "3.0" => "3.0",
-            "-3.0" => "-3.0",
-            "+3.5" => "3.5",
-            "3" => "3.0",
-            ".3" => "0.3",
-            "3." => "3.0",
-            "0" => "0.0",
-            "-.3" => "-0.3",
-            "0003." => "3.0",
-            "3.000" => "3.0",
-        );
+        $pairs = [
+            '-1.23' => '-1.23',
+            '12678967.543233' => '12678967.543233',
+            '+100000.00' => '100000.0',
+            '210' => '210.0',
+            '3.0' => '3.0',
+            '-3.0' => '-3.0',
+            '+3.5' => '3.5',
+            '3' => '3.0',
+            '.3' => '0.3',
+            '3.' => '3.0',
+            '0' => '0.0',
+            '-.3' => '-0.3',
+            '0003.' => '3.0',
+            '3.000' => '3.0',
+        ];
 
         foreach ($pairs as $lexical => $canonical) {
             $this->assertSame($canonical, Decimal::canonicalise($lexical));

--- a/test/EasyRdf/Literal/HTMLTest.php
+++ b/test/EasyRdf/Literal/HTMLTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Literal;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -38,8 +39,7 @@ namespace EasyRdf\Literal;
 
 use EasyRdf\TestCase;
 
-require_once realpath(__DIR__ . '/../../') . '/TestHelper.php';
-
+require_once realpath(__DIR__.'/../../').'/TestHelper.php';
 
 class HTMLTest extends TestCase
 {
@@ -50,7 +50,7 @@ class HTMLTest extends TestCase
         $this->assertStringEquals('<p>Hello World</p>', $literal);
         $this->assertInternalType('string', $literal->getValue());
         $this->assertSame('<p>Hello World</p>', $literal->getValue());
-        $this->assertSame(null, $literal->getLang());
+        $this->assertNull($literal->getLang());
         $this->assertSame('rdf:HTML', $literal->getDatatype());
     }
 

--- a/test/EasyRdf/Literal/HexBinaryTest.php
+++ b/test/EasyRdf/Literal/HexBinaryTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Literal;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -40,8 +41,7 @@ use EasyRdf\Format;
 use EasyRdf\Graph;
 use EasyRdf\TestCase;
 
-require_once realpath(__DIR__ . '/../../') . '/TestHelper.php';
-
+require_once realpath(__DIR__.'/../../').'/TestHelper.php';
 
 class HexBinaryTest extends TestCase
 {
@@ -59,7 +59,7 @@ class HexBinaryTest extends TestCase
         $this->assertStringEquals('48656C6C6F', $literal);
         $this->assertInternalType('string', $literal->getValue());
         $this->assertSame('48656C6C6F', $literal->getValue());
-        $this->assertSame(null, $literal->getLang());
+        $this->assertNull($literal->getLang());
         $this->assertSame('xsd:hexBinary', $literal->getDatatype());
         $this->assertSame('Hello', $literal->toBinary());
     }
@@ -97,11 +97,11 @@ class HexBinaryTest extends TestCase
     {
         $literal = new HexBinary('48656C6C6F');
         $this->assertSame(
-            array(
+            [
                 'type' => 'literal',
                 'value' => '48656C6C6F',
-                'datatype' => 'http://www.w3.org/2001/XMLSchema#hexBinary'
-            ),
+                'datatype' => 'http://www.w3.org/2001/XMLSchema#hexBinary',
+            ],
             $literal->toRdfPhp()
         );
     }
@@ -133,7 +133,7 @@ class HexBinaryTest extends TestCase
             $modulus
         );
         $this->assertInternalType('string', $modulus->getValue());
-        $this->assertSame(null, $modulus->getLang());
+        $this->assertNull($modulus->getLang());
         $this->assertSame('xsd:hexBinary', $modulus->getDatatype());
     }
 }

--- a/test/EasyRdf/Literal/IntegerTest.php
+++ b/test/EasyRdf/Literal/IntegerTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Literal;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -38,8 +39,7 @@ namespace EasyRdf\Literal;
 
 use EasyRdf\TestCase;
 
-require_once realpath(__DIR__ . '/../../') . '/TestHelper.php';
-
+require_once realpath(__DIR__.'/../../').'/TestHelper.php';
 
 class IntegerTest extends TestCase
 {
@@ -50,7 +50,7 @@ class IntegerTest extends TestCase
         $this->assertStringEquals('0', $literal);
         $this->assertInternalType('int', $literal->getValue());
         $this->assertSame(0, $literal->getValue());
-        $this->assertSame(null, $literal->getLang());
+        $this->assertNull($literal->getLang());
         $this->assertSame('xsd:integer', $literal->getDatatype());
     }
 
@@ -61,7 +61,7 @@ class IntegerTest extends TestCase
         $this->assertStringEquals('1', $literal);
         $this->assertInternalType('int', $literal->getValue());
         $this->assertSame(1, $literal->getValue());
-        $this->assertSame(null, $literal->getLang());
+        $this->assertNull($literal->getLang());
         $this->assertSame('xsd:integer', $literal->getDatatype());
     }
 
@@ -72,7 +72,7 @@ class IntegerTest extends TestCase
         $this->assertStringEquals('100', $literal);
         $this->assertInternalType('int', $literal->getValue());
         $this->assertSame(100, $literal->getValue());
-        $this->assertSame(null, $literal->getLang());
+        $this->assertNull($literal->getLang());
         $this->assertSame('xsd:integer', $literal->getDatatype());
     }
 
@@ -83,7 +83,7 @@ class IntegerTest extends TestCase
         $this->assertStringEquals('0100', $literal);
         $this->assertInternalType('int', $literal->getValue());
         $this->assertSame(100, $literal->getValue());
-        $this->assertSame(null, $literal->getLang());
+        $this->assertNull($literal->getLang());
         $this->assertSame('xsd:integer', $literal->getDatatype());
     }
 }

--- a/test/EasyRdf/Literal/XMLTest.php
+++ b/test/EasyRdf/Literal/XMLTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Literal;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -38,8 +39,7 @@ namespace EasyRdf\Literal;
 
 use EasyRdf\TestCase;
 
-require_once realpath(__DIR__ . '/../../') . '/TestHelper.php';
-
+require_once realpath(__DIR__.'/../../').'/TestHelper.php';
 
 class XMLTest extends TestCase
 {
@@ -50,7 +50,7 @@ class XMLTest extends TestCase
         $this->assertStringEquals('<tag>Hello World</tag>', $literal);
         $this->assertInternalType('string', $literal->getValue());
         $this->assertSame('<tag>Hello World</tag>', $literal->getValue());
-        $this->assertSame(null, $literal->getLang());
+        $this->assertNull($literal->getLang());
         $this->assertSame('rdf:XMLLiteral', $literal->getDatatype());
     }
 

--- a/test/EasyRdf/LiteralTest.php
+++ b/test/EasyRdf/LiteralTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EasyRdf;
 
 /**
@@ -31,18 +32,16 @@ namespace EasyRdf;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
-
-require_once dirname(__DIR__).DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(__DIR__).\DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class MyDatatypeClass extends Literal
 {
     public function __toString()
     {
-        return "!".strval($this->value)."!";
+        return '!'.(string) ($this->value).'!';
     }
 }
 
@@ -64,8 +63,8 @@ class LiteralTest extends TestCase
         $literal = Literal::create('Rat');
         $this->assertClass('EasyRdf\Literal', $literal);
         $this->assertSame('Rat', $literal->getValue());
-        $this->assertSame(null, $literal->getLang());
-        $this->assertSame(null, $literal->getDatatype());
+        $this->assertNull($literal->getLang());
+        $this->assertNull($literal->getDatatype());
     }
 
     public function testCreateWithLanguage()
@@ -74,7 +73,7 @@ class LiteralTest extends TestCase
         $this->assertClass('EasyRdf\Literal', $literal);
         $this->assertSame('Rat', $literal->getValue());
         $this->assertSame('en', $literal->getLang());
-        $this->assertSame(null, $literal->getDatatype());
+        $this->assertNull($literal->getDatatype());
     }
 
     public function testCreateWithDatatype()
@@ -82,7 +81,7 @@ class LiteralTest extends TestCase
         $literal = Literal::create(1, null, 'xsd:integer');
         $this->assertClass('EasyRdf\Literal\Integer', $literal);
         $this->assertSame(1, $literal->getValue());
-        $this->assertSame(null, $literal->getLang());
+        $this->assertNull($literal->getLang());
         $this->assertSame('xsd:integer', $literal->getDatatype());
     }
 
@@ -91,7 +90,7 @@ class LiteralTest extends TestCase
         $literal = Literal::create('Rat', 'en', 'http://www.w3.org/2001/XMLSchema#string');
         $this->assertClass('EasyRdf\Literal', $literal);
         $this->assertSame('Rat', $literal->getValue());
-        $this->assertSame(null, $literal->getLang());
+        $this->assertNull($literal->getLang());
         $this->assertSame('xsd:string', $literal->getDatatype());
     }
 
@@ -101,7 +100,7 @@ class LiteralTest extends TestCase
         $this->assertClass('EasyRdf\Literal', $literal);
         $this->assertSame('10', $literal->getValue());
         $this->assertSame('en', $literal->getLang());
-        $this->assertSame(null, $literal->getDatatype());
+        $this->assertNull($literal->getDatatype());
     }
 
     public function testCreateWithObjectDatatype()
@@ -110,7 +109,7 @@ class LiteralTest extends TestCase
         $literal = Literal::create(1, null, $datatype);
         $this->assertClass('EasyRdf\Literal\Integer', $literal);
         $this->assertSame(1, $literal->getValue());
-        $this->assertSame(null, $literal->getLang());
+        $this->assertNull($literal->getLang());
         $this->assertSame('xsd:integer', $literal->getDatatype());
     }
 
@@ -123,7 +122,7 @@ class LiteralTest extends TestCase
         );
         $this->assertClass('EasyRdf\Literal\Integer', $literal);
         $this->assertSame(1, $literal->getValue());
-        $this->assertSame(null, $literal->getLang());
+        $this->assertNull($literal->getLang());
         $this->assertSame('xsd:integer', $literal->getDatatype());
     }
 
@@ -136,44 +135,44 @@ class LiteralTest extends TestCase
         );
         $this->assertClass('EasyRdf\Literal', $literal);
         $this->assertSame('1', $literal->getValue());
-        $this->assertSame(null, $literal->getLang());
-        $this->assertSame(null, $literal->getDatatype());
+        $this->assertNull($literal->getLang());
+        $this->assertNull($literal->getDatatype());
     }
 
     public function testCreateWithAssociativeArray()
     {
-        $literal = Literal::create(array('value' => 'Rat'));
+        $literal = Literal::create(['value' => 'Rat']);
         $this->assertClass('EasyRdf\Literal', $literal);
         $this->assertSame('Rat', $literal->getValue());
-        $this->assertSame(null, $literal->getLang());
-        $this->assertSame(null, $literal->getDatatype());
+        $this->assertNull($literal->getLang());
+        $this->assertNull($literal->getDatatype());
     }
 
     public function testCreateWithAssociativeArrayWithLang()
     {
-        $literal = Literal::create(array( 'value' => 'Rat', 'lang' => 'en'));
+        $literal = Literal::create(['value' => 'Rat', 'lang' => 'en']);
         $this->assertClass('EasyRdf\Literal', $literal);
         $this->assertSame('Rat', $literal->getValue());
-        $this->assertSame(null, $literal->getDatatype());
+        $this->assertNull($literal->getDatatype());
         $this->assertSame('en', $literal->getLang());
     }
 
     public function testCreateWithAssociativeArrayWithXmlLang()
     {
-        $literal = Literal::create(array( 'value' => 'Rattus', 'xml:lang' => 'fr'));
+        $literal = Literal::create(['value' => 'Rattus', 'xml:lang' => 'fr']);
         $this->assertClass('EasyRdf\Literal', $literal);
         $this->assertSame('Rattus', $literal->getValue());
-        $this->assertSame(null, $literal->getDatatype());
+        $this->assertNull($literal->getDatatype());
         $this->assertSame('fr', $literal->getLang());
     }
 
     public function testCreateWithAssociativeArrayWithDatatype()
     {
-        $literal = Literal::create(array('value' => 'Rat','datatype' => 'xsd:string'));
+        $literal = Literal::create(['value' => 'Rat', 'datatype' => 'xsd:string']);
         $this->assertClass('EasyRdf\Literal', $literal);
         $this->assertSame('Rat', $literal->getValue());
         $this->assertSame('xsd:string', $literal->getDatatype());
-        $this->assertSame(null, $literal->getLang());
+        $this->assertNull($literal->getLang());
     }
 
     public function testCreateWithInteger()
@@ -182,7 +181,7 @@ class LiteralTest extends TestCase
         $this->assertClass('EasyRdf\Literal\Integer', $literal);
         $this->assertSame(10, $literal->getValue());
         $this->assertSame('xsd:integer', $literal->getDatatype());
-        $this->assertSame(null, $literal->getLang());
+        $this->assertNull($literal->getLang());
     }
 
     public function testCreateWithFloat()
@@ -191,7 +190,7 @@ class LiteralTest extends TestCase
         $this->assertClass('EasyRdf\Literal', $literal);
         $this->assertSame('1.5', $literal->getValue());
         $this->assertSame('xsd:double', $literal->getDatatype());
-        $this->assertSame(null, $literal->getLang());
+        $this->assertNull($literal->getLang());
     }
 
     public function testCreateWithFloatInBadLocale()
@@ -214,18 +213,18 @@ class LiteralTest extends TestCase
     {
         $literal = Literal::create(true);
         $this->assertClass('EasyRdf\Literal\Boolean', $literal);
-        $this->assertSame(true, $literal->getValue());
+        $this->assertTrue($literal->getValue());
         $this->assertSame('xsd:boolean', $literal->getDatatype());
-        $this->assertSame(null, $literal->getLang());
+        $this->assertNull($literal->getLang());
     }
 
     public function testCreateWithBooleanFalse()
     {
         $literal = Literal::create(false);
         $this->assertClass('EasyRdf\Literal\Boolean', $literal);
-        $this->assertSame(false, $literal->getValue());
+        $this->assertFalse($literal->getValue());
         $this->assertSame('xsd:boolean', $literal->getDatatype());
-        $this->assertSame(null, $literal->getLang());
+        $this->assertNull($literal->getLang());
     }
 
     public function testCreateWithDateTime()
@@ -234,7 +233,7 @@ class LiteralTest extends TestCase
         $literal = Literal::create($dt);
         $this->assertStringEquals('2010-09-08T07:06:05Z', $literal);
         $this->assertEquals($dt, $literal->getValue());
-        $this->assertSame(null, $literal->getLang());
+        $this->assertNull($literal->getLang());
         $this->assertSame('xsd:dateTime', $literal->getDatatype());
     }
 
@@ -243,9 +242,9 @@ class LiteralTest extends TestCase
         $literal = Literal::create(1, null, 'xsd:boolean');
         $this->assertClass('EasyRdf\Literal\Boolean', $literal);
         $this->assertInternalType('bool', $literal->getValue());
-        $this->assertSame(true, $literal->getValue());
+        $this->assertTrue($literal->getValue());
         $this->assertSame('xsd:boolean', $literal->getDatatype());
-        $this->assertSame(null, $literal->getLang());
+        $this->assertNull($literal->getLang());
     }
 
     public function testCreateConvertToBooleanFalse()
@@ -253,9 +252,9 @@ class LiteralTest extends TestCase
         $literal = Literal::create(0, null, 'xsd:boolean');
         $this->assertClass('EasyRdf\Literal\Boolean', $literal);
         $this->assertInternalType('bool', $literal->getValue());
-        $this->assertSame(false, $literal->getValue());
+        $this->assertFalse($literal->getValue());
         $this->assertSame('xsd:boolean', $literal->getDatatype());
-        $this->assertSame(null, $literal->getLang());
+        $this->assertNull($literal->getLang());
     }
 
     public function testCreateConvertToInteger()
@@ -265,7 +264,7 @@ class LiteralTest extends TestCase
         $this->assertInternalType('integer', $literal->getValue());
         $this->assertSame(100, $literal->getValue());
         $this->assertSame('xsd:integer', $literal->getDatatype());
-        $this->assertSame(null, $literal->getLang());
+        $this->assertNull($literal->getLang());
     }
 
     public function testCreateConvertToDecimal()
@@ -275,7 +274,7 @@ class LiteralTest extends TestCase
         $this->assertInternalType('string', $literal->getValue());
         $this->assertSame('1.0', $literal->getValue());
         $this->assertSame('xsd:decimal', $literal->getDatatype());
-        $this->assertSame(null, $literal->getLang());
+        $this->assertNull($literal->getLang());
     }
 
     public function testCreateConvertToString()
@@ -283,18 +282,18 @@ class LiteralTest extends TestCase
         $literal = Literal::create(true, null, 'xsd:string');
         $this->assertClass('EasyRdf\Literal', $literal);
         $this->assertInternalType('string', $literal->getValue());
-        # Hmm, not sure about this, but PHP does the conversion not me:
+        // Hmm, not sure about this, but PHP does the conversion not me:
         $this->assertSame('1', $literal->getValue());
         $this->assertSame('xsd:string', $literal->getDatatype());
-        $this->assertSame(null, $literal->getLang());
+        $this->assertNull($literal->getLang());
     }
 
     public function testConstruct()
     {
         $literal = new Literal('Rat');
         $this->assertSame('Rat', $literal->getValue());
-        $this->assertSame(null, $literal->getLang());
-        $this->assertSame(null, $literal->getDatatype());
+        $this->assertNull($literal->getLang());
+        $this->assertNull($literal->getDatatype());
     }
 
     public function testConstructWithLanguage()
@@ -302,14 +301,14 @@ class LiteralTest extends TestCase
         $literal = new Literal('Rat', 'en');
         $this->assertSame('Rat', $literal->getValue());
         $this->assertSame('en', $literal->getLang());
-        $this->assertSame(null, $literal->getDatatype());
+        $this->assertNull($literal->getDatatype());
     }
 
     public function testConstructWithDatatype()
     {
         $literal = new Literal(1, null, 'xsd:integer');
         $this->assertSame('1', $literal->getValue());
-        $this->assertSame(null, $literal->getLang());
+        $this->assertNull($literal->getLang());
         $this->assertSame('xsd:integer', $literal->getDatatype());
     }
 
@@ -318,7 +317,7 @@ class LiteralTest extends TestCase
         $datatype = new ParsedUri('http://www.w3.org/2001/XMLSchema#integer');
         $literal = new Literal(1, null, $datatype);
         $this->assertSame('1', $literal->getValue());
-        $this->assertSame(null, $literal->getLang());
+        $this->assertNull($literal->getLang());
         $this->assertSame('xsd:integer', $literal->getDatatype());
     }
 
@@ -334,17 +333,17 @@ class LiteralTest extends TestCase
     public function testToString()
     {
         $literal = Literal::create('Rat');
-        $this->assertSame('Rat', strval($literal));
+        $this->assertSame('Rat', (string) $literal);
     }
 
     public function testToRdfPhp()
     {
         $literal = Literal::create('Rat');
         $this->assertSame(
-            array(
+            [
                'type' => 'literal',
-               'value' => 'Rat'
-            ),
+               'value' => 'Rat',
+            ],
             $literal->toRdfPhp()
         );
     }
@@ -353,11 +352,11 @@ class LiteralTest extends TestCase
     {
         $literal = new Literal('Chat', 'fr');
         $this->assertSame(
-            array(
+            [
                'type' => 'literal',
                'value' => 'Chat',
-               'lang' => 'fr'
-            ),
+               'lang' => 'fr',
+            ],
             $literal->toRdfPhp()
         );
     }
@@ -366,18 +365,18 @@ class LiteralTest extends TestCase
     {
         $literal = Literal::create(44);
         $this->assertSame(
-            array(
+            [
                'type' => 'literal',
                'value' => '44',
-               'datatype' => 'http://www.w3.org/2001/XMLSchema#integer'
-            ),
+               'datatype' => 'http://www.w3.org/2001/XMLSchema#integer',
+            ],
             $literal->toRdfPhp()
         );
     }
 
     public function testDumpValue()
     {
-        $literal = Literal::create("hello & world");
+        $literal = Literal::create('hello & world');
         $this->assertSame(
             '"hello & world"',
             $literal->dumpValue('text')
@@ -422,7 +421,7 @@ class LiteralTest extends TestCase
         $this->assertStringEquals('!foobar!', $literal);
         $this->assertSame('foobar', $literal->getValue());
         $this->assertSame('ex:mytype', $literal->getDatatype());
-        $this->assertSame(null, $literal->getLang());
+        $this->assertNull($literal->getLang());
     }
 
     public function testCreateCustomClass()
@@ -433,7 +432,7 @@ class LiteralTest extends TestCase
         $this->assertStringEquals('!foobar!', $literal);
         $this->assertSame('foobar', $literal->getValue());
         $this->assertSame('ex:mytype', $literal->getDatatype());
-        $this->assertSame(null, $literal->getLang());
+        $this->assertNull($literal->getLang());
     }
 
     public function testSetDatatypeMappingNull()
@@ -460,7 +459,7 @@ class LiteralTest extends TestCase
             'InvalidArgumentException',
             '$datatype should be a string and cannot be null or empty'
         );
-        Literal::setDatatypeMapping(array(), 'EasyRdf\MyDatatypeClass');
+        Literal::setDatatypeMapping([], 'EasyRdf\MyDatatypeClass');
     }
 
     public function testSetDatatypeMappingClassNull()
@@ -487,7 +486,7 @@ class LiteralTest extends TestCase
             'InvalidArgumentException',
             '$class should be a string and cannot be null or empty'
         );
-        Literal::setDatatypeMapping('ex:mytype', array());
+        Literal::setDatatypeMapping('ex:mytype', []);
     }
 
     public function testDeleteDatatypeMappingNull()
@@ -514,6 +513,6 @@ class LiteralTest extends TestCase
             'InvalidArgumentException',
             '$datatype should be a string and cannot be null or empty'
         );
-        Literal::deleteDatatypeMapping(array());
+        Literal::deleteDatatypeMapping([]);
     }
 }

--- a/test/EasyRdf/NamespaceTest.php
+++ b/test/EasyRdf/NamespaceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EasyRdf;
 
 /**
@@ -31,18 +32,16 @@ namespace EasyRdf;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2014 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
-
-require_once dirname(__DIR__).DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(__DIR__).\DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class NamespaceTest extends TestCase
 {
     /** @var Graph */
     private $graph;
-    /** @var Resource */
+    /** @var resource */
     private $resource;
 
     public function setUp()
@@ -128,7 +127,7 @@ class NamespaceTest extends TestCase
             'InvalidArgumentException',
             '$prefix should be a string and cannot be null or empty'
         );
-        RdfNamespace::get(array());
+        RdfNamespace::get([]);
     }
 
     public function testGetNonAlphanumeric()
@@ -183,7 +182,7 @@ class NamespaceTest extends TestCase
             'InvalidArgumentException',
             '$prefix should be a string and cannot be null or empty'
         );
-        RdfNamespace::set(array(), 'http://purl.org/ontology/ko/');
+        RdfNamespace::set([], 'http://purl.org/ontology/ko/');
     }
 
     public function testAddNamespaceShortInvalid()
@@ -219,7 +218,7 @@ class NamespaceTest extends TestCase
             'InvalidArgumentException',
             '$long should be a string and cannot be null or empty'
         );
-        RdfNamespace::set('ko', array());
+        RdfNamespace::set('ko', []);
     }
 
     public function testDeleteNamespace()
@@ -279,7 +278,7 @@ class NamespaceTest extends TestCase
     {
         RdfNamespace::setDefault('http://ogp.me/ns#');
         RdfNamespace::setDefault('');
-        $this->assertSame(null, RdfNamespace::getDefault());
+        $this->assertNull(RdfNamespace::getDefault());
     }
 
     public function testSetDefaultUnknown()
@@ -294,7 +293,7 @@ class NamespaceTest extends TestCase
     public function testSplitUriFoafName()
     {
         $this->assertSame(
-            array('foaf', 'name'),
+            ['foaf', 'name'],
             RdfNamespace::splitUri('http://xmlns.com/foaf/0.1/name')
         );
     }
@@ -302,15 +301,14 @@ class NamespaceTest extends TestCase
     public function testSplitUriResource()
     {
         $this->assertSame(
-            array('foaf','name'),
+            ['foaf', 'name'],
             RdfNamespace::splitUri($this->resource)
         );
     }
 
     public function testSlitUriUnknown()
     {
-        $this->assertSame(
-            null,
+        $this->assertNull(
             RdfNamespace::splitUri('http://example.com/ns/foo/bar')
         );
     }
@@ -318,7 +316,7 @@ class NamespaceTest extends TestCase
     public function testSplitUriAndCreateOneUnknown()
     {
         $this->assertSame(
-            array('ns0', 'bar'),
+            ['ns0', 'bar'],
             RdfNamespace::splitUri('http://example.com/ns/foo/bar', true)
         );
     }
@@ -326,11 +324,11 @@ class NamespaceTest extends TestCase
     public function testSplitUriAndCreateTwice()
     {
         $this->assertSame(
-            array('ns0', 'bar'),
+            ['ns0', 'bar'],
             RdfNamespace::splitUri('http://example.com/ns/foo/bar', true)
         );
         $this->assertSame(
-            array('ns0', 'bar'),
+            ['ns0', 'bar'],
             RdfNamespace::splitUri('http://example.com/ns/foo/bar', true)
         );
     }
@@ -338,19 +336,18 @@ class NamespaceTest extends TestCase
     public function testSplitUriAndCreateTwoUnknown()
     {
         $this->assertSame(
-            array('ns0', 'bar'),
+            ['ns0', 'bar'],
             RdfNamespace::splitUri('http://example1.org/ns/foo/bar', true)
         );
         $this->assertSame(
-            array('ns1', 'bar'),
+            ['ns1', 'bar'],
             RdfNamespace::splitUri('http://example2.org/ns/foo/bar', true)
         );
     }
 
     public function testSplitUriUnsplitable()
     {
-        $this->assertSame(
-            null,
+        $this->assertNull(
             RdfNamespace::splitUri('http://example.com/foo/', true)
         );
     }
@@ -381,7 +378,6 @@ class NamespaceTest extends TestCase
         );
         RdfNamespace::splitUri($this);
     }
-
 
     public function testShortenFoafName()
     {
@@ -423,8 +419,7 @@ class NamespaceTest extends TestCase
 
     public function testShortenUnknown()
     {
-        $this->assertSame(
-            null,
+        $this->assertNull(
             RdfNamespace::shorten('http://example.com/ns/foo/bar')
         );
     }
@@ -451,8 +446,7 @@ class NamespaceTest extends TestCase
 
     public function testShortenUnshortenable()
     {
-        $this->assertSame(
-            null,
+        $this->assertNull(
             RdfNamespace::shorten('http://example.com/foo/', true)
         );
     }
@@ -502,8 +496,7 @@ class NamespaceTest extends TestCase
 
     public function testPrefixOfUnknownUrl()
     {
-        $this->assertSame(
-            null,
+        $this->assertNull(
             RdfNamespace::prefixOfUri('http://www.aelius.com/njh/')
         );
     }
@@ -544,7 +537,7 @@ class NamespaceTest extends TestCase
             'InvalidArgumentException',
             '$uri should be a string or EasyRdf\Resource'
         );
-        RdfNamespace::prefixOfUri(array());
+        RdfNamespace::prefixOfUri([]);
     }
 
     public function testExpandFoafName()

--- a/test/EasyRdf/ParsedUriTest.php
+++ b/test/EasyRdf/ParsedUriTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EasyRdf;
 
 /**
@@ -31,12 +32,10 @@ namespace EasyRdf;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
-
-require_once dirname(__DIR__).DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(__DIR__).\DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class ParsedUriTest extends TestCase
 {
@@ -53,13 +52,13 @@ class ParsedUriTest extends TestCase
     public function testConstruct()
     {
         $uri = new ParsedUri(
-            array(
+            [
                 'scheme' => 'http',
                 'authority' => 'example.com',
                 'path' => '/foo/bar',
                 'query' => 'k=v',
-                'fragment' => 'frag'
-            )
+                'fragment' => 'frag',
+            ]
         );
         $this->assertStringEquals('http://example.com/foo/bar?k=v#frag', $uri);
     }
@@ -70,8 +69,8 @@ class ParsedUriTest extends TestCase
         $this->assertSame('http', $uri->getScheme());
         $this->assertSame('www.ietf.org', $uri->getAuthority());
         $this->assertSame('/rfc/rfc2396.txt', $uri->getPath());
-        $this->assertSame(null, $uri->getQuery());
-        $this->assertSame(null, $uri->getFragment());
+        $this->assertNull($uri->getQuery());
+        $this->assertNull($uri->getFragment());
         $this->assertStringEquals('http://www.ietf.org/rfc/rfc2396.txt', $uri);
         $this->assertTrue($uri->isAbsolute());
     }
@@ -82,8 +81,8 @@ class ParsedUriTest extends TestCase
         $this->assertSame('file', $uri->getScheme());
         $this->assertSame('', $uri->getAuthority());
         $this->assertSame('/etc/hosts', $uri->getPath());
-        $this->assertSame(null, $uri->getQuery());
-        $this->assertSame(null, $uri->getFragment());
+        $this->assertNull($uri->getQuery());
+        $this->assertNull($uri->getFragment());
         $this->assertStringEquals('file:///etc/hosts', $uri);
         $this->assertTrue($uri->isAbsolute());
     }
@@ -94,8 +93,8 @@ class ParsedUriTest extends TestCase
         $this->assertSame('ftp', $uri->getScheme());
         $this->assertSame('ftp.is.co.za', $uri->getAuthority());
         $this->assertSame('/rfc/rfc1808.txt', $uri->getPath());
-        $this->assertSame(null, $uri->getQuery());
-        $this->assertSame(null, $uri->getFragment());
+        $this->assertNull($uri->getQuery());
+        $this->assertNull($uri->getFragment());
         $this->assertStringEquals('ftp://ftp.is.co.za/rfc/rfc1808.txt', $uri);
         $this->assertTrue($uri->isAbsolute());
     }
@@ -107,7 +106,7 @@ class ParsedUriTest extends TestCase
         $this->assertSame('[2001:db8::7]', $uri->getAuthority());
         $this->assertSame('/c=GB', $uri->getPath());
         $this->assertSame('objectClass?one', $uri->getQuery());
-        $this->assertSame(null, $uri->getFragment());
+        $this->assertNull($uri->getFragment());
         $this->assertStringEquals('ldap://[2001:db8::7]/c=GB?objectClass?one', $uri);
         $this->assertTrue($uri->isAbsolute());
     }
@@ -116,10 +115,10 @@ class ParsedUriTest extends TestCase
     {
         $uri = new ParsedUri('mailto:John.Doe@example.com');
         $this->assertSame('mailto', $uri->getScheme());
-        $this->assertSame(null, $uri->getAuthority());
+        $this->assertNull($uri->getAuthority());
         $this->assertSame('John.Doe@example.com', $uri->getPath());
-        $this->assertSame(null, $uri->getQuery());
-        $this->assertSame(null, $uri->getFragment());
+        $this->assertNull($uri->getQuery());
+        $this->assertNull($uri->getFragment());
         $this->assertStringEquals('mailto:John.Doe@example.com', $uri);
         $this->assertTrue($uri->isAbsolute());
     }
@@ -128,10 +127,10 @@ class ParsedUriTest extends TestCase
     {
         $uri = new ParsedUri('news:comp.infosystems.www.servers.unix');
         $this->assertSame('news', $uri->getScheme());
-        $this->assertSame(null, $uri->getAuthority());
+        $this->assertNull($uri->getAuthority());
         $this->assertSame('comp.infosystems.www.servers.unix', $uri->getPath());
-        $this->assertSame(null, $uri->getQuery());
-        $this->assertSame(null, $uri->getFragment());
+        $this->assertNull($uri->getQuery());
+        $this->assertNull($uri->getFragment());
         $this->assertStringEquals('news:comp.infosystems.www.servers.unix', $uri);
         $this->assertTrue($uri->isAbsolute());
     }
@@ -140,10 +139,10 @@ class ParsedUriTest extends TestCase
     {
         $uri = new ParsedUri('tel:+1-816-555-1212');
         $this->assertSame('tel', $uri->getScheme());
-        $this->assertSame(null, $uri->getAuthority());
+        $this->assertNull($uri->getAuthority());
         $this->assertSame('+1-816-555-1212', $uri->getPath());
-        $this->assertSame(null, $uri->getQuery());
-        $this->assertSame(null, $uri->getFragment());
+        $this->assertNull($uri->getQuery());
+        $this->assertNull($uri->getFragment());
         $this->assertStringEquals('tel:+1-816-555-1212', $uri);
         $this->assertTrue($uri->isAbsolute());
     }
@@ -154,8 +153,8 @@ class ParsedUriTest extends TestCase
         $this->assertSame('telnet', $uri->getScheme());
         $this->assertSame('192.0.2.16:80', $uri->getAuthority());
         $this->assertSame('/', $uri->getPath());
-        $this->assertSame(null, $uri->getQuery());
-        $this->assertSame(null, $uri->getFragment());
+        $this->assertNull($uri->getQuery());
+        $this->assertNull($uri->getFragment());
         $this->assertStringEquals('telnet://192.0.2.16:80/', $uri);
         $this->assertTrue($uri->isAbsolute());
     }
@@ -164,10 +163,10 @@ class ParsedUriTest extends TestCase
     {
         $uri = new ParsedUri('urn:oasis:names:specification:docbook:dtd:xml:4.1.2');
         $this->assertSame('urn', $uri->getScheme());
-        $this->assertSame(null, $uri->getAuthority());
+        $this->assertNull($uri->getAuthority());
         $this->assertSame('oasis:names:specification:docbook:dtd:xml:4.1.2', $uri->getPath());
-        $this->assertSame(null, $uri->getQuery());
-        $this->assertSame(null, $uri->getFragment());
+        $this->assertNull($uri->getQuery());
+        $this->assertNull($uri->getFragment());
         $this->assertStringEquals('urn:oasis:names:specification:docbook:dtd:xml:4.1.2', $uri);
         $this->assertTrue($uri->isAbsolute());
     }
@@ -175,11 +174,11 @@ class ParsedUriTest extends TestCase
     public function testParseRelative()
     {
         $uri = new ParsedUri('/foo/bar');
-        $this->assertSame(null, $uri->getScheme());
-        $this->assertSame(null, $uri->getAuthority());
+        $this->assertNull($uri->getScheme());
+        $this->assertNull($uri->getAuthority());
         $this->assertSame('/foo/bar', $uri->getPath());
-        $this->assertSame(null, $uri->getQuery());
-        $this->assertSame(null, $uri->getFragment());
+        $this->assertNull($uri->getQuery());
+        $this->assertNull($uri->getFragment());
         $this->assertStringEquals('/foo/bar', $uri);
         $this->assertTrue($uri->isRelative());
     }
@@ -190,7 +189,7 @@ class ParsedUriTest extends TestCase
         $this->assertSame('http', $uri->getScheme());
         $this->assertSame('www.example.com', $uri->getAuthority());
         $this->assertSame('/foo', $uri->getPath());
-        $this->assertSame(null, $uri->getQuery());
+        $this->assertNull($uri->getQuery());
         $this->assertSame('', $uri->getFragment());
         $this->assertStringEquals('http://www.example.com/foo#', $uri);
         $this->assertTrue($uri->isAbsolute());
@@ -203,7 +202,7 @@ class ParsedUriTest extends TestCase
         $this->assertSame('www.example.com', $uri->getAuthority());
         $this->assertSame('/foo', $uri->getPath());
         $this->assertSame('', $uri->getQuery());
-        $this->assertSame(null, $uri->getFragment());
+        $this->assertNull($uri->getFragment());
         $this->assertStringEquals('http://www.example.com/foo?', $uri);
         $this->assertTrue($uri->isAbsolute());
     }
@@ -254,8 +253,8 @@ class ParsedUriTest extends TestCase
     {
         $base = new ParsedUri('http://example.com');
         $this->assertStringEquals(
-            "http://example.com/filename",
-            $base->resolve("filename")
+            'http://example.com/filename',
+            $base->resolve('filename')
         );
     }
 
@@ -263,7 +262,7 @@ class ParsedUriTest extends TestCase
     {
         $uri = new ParsedUri('http://example.com/foo/bar?q#f');
         $this->assertSame(
-            "http://example.com/foo/bar?q#f",
+            'http://example.com/foo/bar?q#f',
             $uri->toString()
         );
     }
@@ -339,346 +338,345 @@ class ParsedUriTest extends TestCase
     public function testResolveReferenceUriNormal1()
     {
         $this->assertStringEquals(
-            "g:h",
-            $this->baseUri->resolve("g:h")
+            'g:h',
+            $this->baseUri->resolve('g:h')
         );
     }
 
     public function testResolveReferenceUriNormal2()
     {
         $this->assertStringEquals(
-            "http://a/b/c/g",
-            $this->baseUri->resolve("g")
+            'http://a/b/c/g',
+            $this->baseUri->resolve('g')
         );
     }
 
     public function testResolveReferenceUriNormal3()
     {
         $this->assertStringEquals(
-            "http://a/b/c/g",
-            $this->baseUri->resolve("./g")
+            'http://a/b/c/g',
+            $this->baseUri->resolve('./g')
         );
     }
 
     public function testResolveReferenceUriNormal4()
     {
         $this->assertStringEquals(
-            "http://a/b/c/g/",
-            $this->baseUri->resolve("g/")
+            'http://a/b/c/g/',
+            $this->baseUri->resolve('g/')
         );
     }
 
     public function testResolveReferenceUriNormal5()
     {
         $this->assertStringEquals(
-            "http://a/g",
-            $this->baseUri->resolve("/g")
+            'http://a/g',
+            $this->baseUri->resolve('/g')
         );
     }
 
     public function testResolveReferenceUriNormal6()
     {
         $this->assertStringEquals(
-            "http://g",
-            $this->baseUri->resolve("//g")
+            'http://g',
+            $this->baseUri->resolve('//g')
         );
     }
 
     public function testResolveReferenceUriNormal7()
     {
         $this->assertStringEquals(
-            "http://a/b/c/d;p?y",
-            $this->baseUri->resolve("?y")
+            'http://a/b/c/d;p?y',
+            $this->baseUri->resolve('?y')
         );
     }
 
     public function testResolveReferenceUriNormal8()
     {
         $this->assertStringEquals(
-            "http://a/b/c/g?y",
-            $this->baseUri->resolve("g?y")
+            'http://a/b/c/g?y',
+            $this->baseUri->resolve('g?y')
         );
     }
 
     public function testResolveReferenceUriNormal9()
     {
         $this->assertStringEquals(
-            "http://a/b/c/d;p?q#s",
-            $this->baseUri->resolve("#s")
+            'http://a/b/c/d;p?q#s',
+            $this->baseUri->resolve('#s')
         );
     }
 
     public function testResolveReferenceUriNormal10()
     {
         $this->assertStringEquals(
-            "http://a/b/c/g#s",
-            $this->baseUri->resolve("g#s")
+            'http://a/b/c/g#s',
+            $this->baseUri->resolve('g#s')
         );
     }
 
     public function testResolveReferenceUriNormal11()
     {
         $this->assertStringEquals(
-            "http://a/b/c/g?y#s",
-            $this->baseUri->resolve("g?y#s")
+            'http://a/b/c/g?y#s',
+            $this->baseUri->resolve('g?y#s')
         );
     }
 
     public function testResolveReferenceUriNormal12()
     {
         $this->assertStringEquals(
-            "http://a/b/c/g;x",
-            $this->baseUri->resolve("g;x")
+            'http://a/b/c/g;x',
+            $this->baseUri->resolve('g;x')
         );
     }
 
     public function testResolveReferenceUriNormal13()
     {
         $this->assertStringEquals(
-            "http://a/b/c/g;x",
-            $this->baseUri->resolve("g;x")
+            'http://a/b/c/g;x',
+            $this->baseUri->resolve('g;x')
         );
     }
 
     public function testResolveReferenceUriNormal14()
     {
         $this->assertStringEquals(
-            "http://a/b/c/g;x?y#s",
-            $this->baseUri->resolve("g;x?y#s")
+            'http://a/b/c/g;x?y#s',
+            $this->baseUri->resolve('g;x?y#s')
         );
     }
 
     public function testResolveReferenceUriNormal15()
     {
         $this->assertStringEquals(
-            "http://a/b/c/d;p?q",
-            $this->baseUri->resolve("")
+            'http://a/b/c/d;p?q',
+            $this->baseUri->resolve('')
         );
     }
 
     public function testResolveReferenceUriNormal16()
     {
         $this->assertStringEquals(
-            "http://a/b/c/",
-            $this->baseUri->resolve(".")
+            'http://a/b/c/',
+            $this->baseUri->resolve('.')
         );
     }
 
     public function testResolveReferenceUriNormal17()
     {
         $this->assertStringEquals(
-            "http://a/b/c/",
-            $this->baseUri->resolve("./")
+            'http://a/b/c/',
+            $this->baseUri->resolve('./')
         );
     }
 
     public function testResolveReferenceUriNormal18()
     {
         $this->assertStringEquals(
-            "http://a/b/",
-            $this->baseUri->resolve("..")
+            'http://a/b/',
+            $this->baseUri->resolve('..')
         );
     }
 
     public function testResolveReferenceUriNormal19()
     {
         $this->assertStringEquals(
-            "http://a/b/",
-            $this->baseUri->resolve("../")
+            'http://a/b/',
+            $this->baseUri->resolve('../')
         );
     }
 
     public function testResolveReferenceUriNormal20()
     {
         $this->assertStringEquals(
-            "http://a/b/g",
-            $this->baseUri->resolve("../g")
+            'http://a/b/g',
+            $this->baseUri->resolve('../g')
         );
     }
 
     public function testResolveReferenceUriNormal21()
     {
         $this->assertStringEquals(
-            "http://a/",
-            $this->baseUri->resolve("../..")
+            'http://a/',
+            $this->baseUri->resolve('../..')
         );
     }
 
     public function testResolveReferenceUriNormal22()
     {
         $this->assertStringEquals(
-            "http://a/",
-            $this->baseUri->resolve("../../")
+            'http://a/',
+            $this->baseUri->resolve('../../')
         );
     }
 
     public function testResolveReferenceUriNormal23()
     {
         $this->assertStringEquals(
-            "http://a/g",
-            $this->baseUri->resolve("../../g")
+            'http://a/g',
+            $this->baseUri->resolve('../../g')
         );
     }
-
 
     /* RFC3986 5.4.2 Abnormal Examples */
     public function testResolveReferenceUriAbnormal1()
     {
         $this->assertStringEquals(
-            "http://a/g",
-            $this->baseUri->resolve("../../../g")
+            'http://a/g',
+            $this->baseUri->resolve('../../../g')
         );
     }
 
     public function testResolveReferenceUriAbnormal2()
     {
         $this->assertStringEquals(
-            "http://a/g",
-            $this->baseUri->resolve("../../../../g")
+            'http://a/g',
+            $this->baseUri->resolve('../../../../g')
         );
     }
 
     public function testResolveReferenceUriAbnormal3()
     {
         $this->assertStringEquals(
-            "http://a/g",
-            $this->baseUri->resolve("/./g")
+            'http://a/g',
+            $this->baseUri->resolve('/./g')
         );
     }
 
     public function testResolveReferenceUriAbnormal4()
     {
         $this->assertStringEquals(
-            "http://a/g",
-            $this->baseUri->resolve("/../g")
+            'http://a/g',
+            $this->baseUri->resolve('/../g')
         );
     }
 
     public function testResolveReferenceUriAbnormal5()
     {
         $this->assertStringEquals(
-            "http://a/b/c/g.",
-            $this->baseUri->resolve("g.")
+            'http://a/b/c/g.',
+            $this->baseUri->resolve('g.')
         );
     }
 
     public function testResolveReferenceUriAbnormal6()
     {
         $this->assertStringEquals(
-            "http://a/b/c/.g",
-            $this->baseUri->resolve(".g")
+            'http://a/b/c/.g',
+            $this->baseUri->resolve('.g')
         );
     }
 
     public function testResolveReferenceUriAbnormal7()
     {
         $this->assertStringEquals(
-            "http://a/b/c/g..",
-            $this->baseUri->resolve("g..")
+            'http://a/b/c/g..',
+            $this->baseUri->resolve('g..')
         );
     }
 
     public function testResolveReferenceUriAbnormal8()
     {
         $this->assertStringEquals(
-            "http://a/b/c/..g",
-            $this->baseUri->resolve("..g")
+            'http://a/b/c/..g',
+            $this->baseUri->resolve('..g')
         );
     }
 
     public function testResolveReferenceUriAbnormal9()
     {
         $this->assertStringEquals(
-            "http://a/b/g",
-            $this->baseUri->resolve("./../g")
+            'http://a/b/g',
+            $this->baseUri->resolve('./../g')
         );
     }
 
     public function testResolveReferenceUriAbnormal10()
     {
         $this->assertStringEquals(
-            "http://a/b/c/g/",
-            $this->baseUri->resolve("./g/.")
+            'http://a/b/c/g/',
+            $this->baseUri->resolve('./g/.')
         );
     }
 
     public function testResolveReferenceUriAbnormal11()
     {
         $this->assertStringEquals(
-            "http://a/b/c/g/h",
-            $this->baseUri->resolve("g/./h")
+            'http://a/b/c/g/h',
+            $this->baseUri->resolve('g/./h')
         );
     }
 
     public function testResolveReferenceUriAbnormal12()
     {
         $this->assertStringEquals(
-            "http://a/b/c/h",
-            $this->baseUri->resolve("g/../h")
+            'http://a/b/c/h',
+            $this->baseUri->resolve('g/../h')
         );
     }
 
     public function testResolveReferenceUriAbnormal13()
     {
         $this->assertStringEquals(
-            "http://a/b/c/g;x=1/y",
-            $this->baseUri->resolve("g;x=1/./y")
+            'http://a/b/c/g;x=1/y',
+            $this->baseUri->resolve('g;x=1/./y')
         );
     }
 
     public function testResolveReferenceUriAbnormal14()
     {
         $this->assertStringEquals(
-            "http://a/b/c/y",
-            $this->baseUri->resolve("g;x=1/../y")
+            'http://a/b/c/y',
+            $this->baseUri->resolve('g;x=1/../y')
         );
     }
 
     public function testResolveReferenceUriAbnormal15()
     {
         $this->assertStringEquals(
-            "http://a/b/c/y",
-            $this->baseUri->resolve("g;x=1/../y")
+            'http://a/b/c/y',
+            $this->baseUri->resolve('g;x=1/../y')
         );
     }
 
     public function testResolveReferenceUriAbnormal16()
     {
         $this->assertStringEquals(
-            "http://a/b/c/g?y/./x",
-            $this->baseUri->resolve("g?y/./x")
+            'http://a/b/c/g?y/./x',
+            $this->baseUri->resolve('g?y/./x')
         );
     }
 
     public function testResolveReferenceUriAbnormal17()
     {
         $this->assertStringEquals(
-            "http://a/b/c/g?y/../x",
-            $this->baseUri->resolve("g?y/../x")
+            'http://a/b/c/g?y/../x',
+            $this->baseUri->resolve('g?y/../x')
         );
     }
 
     public function testResolveReferenceUriAbnormal18()
     {
         $this->assertStringEquals(
-            "http://a/b/c/g#s/./x",
-            $this->baseUri->resolve("g#s/./x")
+            'http://a/b/c/g#s/./x',
+            $this->baseUri->resolve('g#s/./x')
         );
     }
 
     public function testResolveReferenceUriAbnormal19()
     {
         $this->assertStringEquals(
-            "http://a/b/c/g#s/../x",
-            $this->baseUri->resolve("g#s/../x")
+            'http://a/b/c/g#s/../x',
+            $this->baseUri->resolve('g#s/../x')
         );
     }
 
     public function testResolveReferenceUriAbnormal20()
     {
         $this->assertStringEquals(
-            "http:g",
-            $this->baseUri->resolve("http:g")
+            'http:g',
+            $this->baseUri->resolve('http:g')
         );
     }
 }

--- a/test/EasyRdf/Parser/ArcTest.php
+++ b/test/EasyRdf/Parser/ArcTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Parser;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -39,8 +40,8 @@ namespace EasyRdf\Parser;
 use EasyRdf\Graph;
 use EasyRdf\TestCase;
 
-require_once dirname(dirname(__DIR__)).
-             DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(\dirname(__DIR__)).
+             \DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class ArcTest extends TestCase
 {
@@ -58,7 +59,7 @@ class ArcTest extends TestCase
             $this->data = readFixture('foaf.rdf');
         } else {
             $this->markTestSkipped(
-                "ARC2 library is not available."
+                'ARC2 library is not available.'
             );
         }
     }
@@ -83,7 +84,7 @@ class ArcTest extends TestCase
         $this->assertClass('EasyRdf\Literal', $name);
         $this->assertStringEquals('Joe Bloggs', $name);
         $this->assertSame('en', $name->getLang());
-        $this->assertSame(null, $name->getDatatype());
+        $this->assertNull($name->getDatatype());
 
         $foaf = $this->graph->resource('http://www.example.com/joe/foaf.rdf');
         $this->assertNotNull($foaf);

--- a/test/EasyRdf/Parser/ExceptionTest.php
+++ b/test/EasyRdf/Parser/ExceptionTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Parser;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -38,8 +39,8 @@ namespace EasyRdf\Parser;
 
 use EasyRdf\TestCase;
 
-require_once dirname(dirname(__DIR__)).
-             DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(\dirname(__DIR__)).
+             \DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class ExceptionTest extends TestCase
 {

--- a/test/EasyRdf/Parser/JsonLdTest.php
+++ b/test/EasyRdf/Parser/JsonLdTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Parser;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -40,13 +41,12 @@ use EasyRdf\Format;
 use EasyRdf\Graph;
 use EasyRdf\TestCase;
 
-require_once dirname(dirname(__DIR__)).
-             DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(\dirname(__DIR__)).
+             \DIRECTORY_SEPARATOR.'TestHelper.php';
 
 /**
  * JSON-LD parsing tests
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2014 Markus Lanthaler
  * @author     Markus Lanthaler <mail@markus-lanthaler.com>
  * @license    http://www.opensource.org/licenses/bsd-license.php
@@ -81,7 +81,7 @@ class JsonLdTest extends TestCase
         $this->assertClass('EasyRdf\Literal', $name);
         $this->assertSame('Joe Bloggs', $name->getValue());
         $this->assertSame('en', $name->getLang());
-        $this->assertSame(null, $name->getDatatype());
+        $this->assertNull($name->getDatatype());
 
         $project = $joe->get('foaf:currentProject');
         $this->assertNotNull($project);

--- a/test/EasyRdf/Parser/JsonTest.php
+++ b/test/EasyRdf/Parser/JsonTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Parser;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -40,8 +41,8 @@ use EasyRdf\Format;
 use EasyRdf\Graph;
 use EasyRdf\TestCase;
 
-require_once dirname(dirname(__DIR__)).
-             DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(\dirname(__DIR__)).
+             \DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class JsonTest extends TestCase
 {
@@ -72,7 +73,7 @@ class JsonTest extends TestCase
         $this->assertClass('EasyRdf\Literal', $name);
         $this->assertSame('Joe Bloggs', $name->getValue());
         $this->assertSame('en', $name->getLang());
-        $this->assertSame(null, $name->getDatatype());
+        $this->assertNull($name->getDatatype());
 
         $project = $joe->get('foaf:currentProject');
         $this->assertNotNull($project);
@@ -96,7 +97,7 @@ class JsonTest extends TestCase
         $this->assertClass('EasyRdf\Literal', $name);
         $this->assertSame('Joe Bloggs', $name->getValue());
         $this->assertSame('en', $name->getLang());
-        $this->assertSame(null, $name->getDatatype());
+        $this->assertNull($name->getDatatype());
 
         $project = $joe->get('foaf:currentProject');
         $this->assertNotNull($project);
@@ -117,7 +118,7 @@ class JsonTest extends TestCase
 
     public function testParseBadJson()
     {
-        # Test parsing JSON with 'bad' bnode identifiers
+        // Test parsing JSON with 'bad' bnode identifiers
         $data = readFixture('foaf.bad-json');
         $count = $this->parser->parse($this->graph, $data, 'json', 'http://www.bbc.co.uk/');
         $this->assertSame(14, $count);
@@ -130,7 +131,7 @@ class JsonTest extends TestCase
         $this->assertTrue($project->isBNode());
         $this->assertStringEquals("Joe's Current Project", $project->label());
 
-        # Test going the other way
+        // Test going the other way
         $project2 = $this->graph->resource('foaf:Project')->get('^rdf:type');
         $this->assertNotNull($project2);
         $this->assertTrue($project2->isBNode());

--- a/test/EasyRdf/Parser/NtriplesTest.php
+++ b/test/EasyRdf/Parser/NtriplesTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Parser;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -39,8 +40,8 @@ namespace EasyRdf\Parser;
 use EasyRdf\Graph;
 use EasyRdf\TestCase;
 
-require_once dirname(dirname(__DIR__)).
-             DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(\dirname(__DIR__)).
+             \DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class NtriplesTest extends TestCase
 {
@@ -72,7 +73,7 @@ class NtriplesTest extends TestCase
         $this->assertClass('EasyRdf\Literal', $name);
         $this->assertSame('Joe Bloggs', $name->getValue());
         $this->assertSame('en', $name->getLang());
-        $this->assertSame(null, $name->getDatatype());
+        $this->assertNull($name->getDatatype());
     }
 
     public function testParseBnode()
@@ -88,12 +89,12 @@ class NtriplesTest extends TestCase
 
         $bnode1 = $this->graph->resource('_:genid1');
         $this->assertNotNull($bnode1);
-        $this->assertSame(true, $bnode1->isBNode());
+        $this->assertTrue($bnode1->isBNode());
         $this->assertStringEquals('c', $bnode1->get('<http://example.com/b>'));
 
         $bnode2 = $this->graph->resource('_:genid2');
         $this->assertNotNull($bnode2);
-        $this->assertSame(true, $bnode2->isBNode());
+        $this->assertTrue($bnode2->isBNode());
         $this->assertSame($bnode1, $bnode2->get('<http://example.com/e>'));
     }
 
@@ -109,11 +110,11 @@ class NtriplesTest extends TestCase
         $this->assertSame(2, $count);
 
         $bnode1 = $this->graph->resource('_:genid1');
-        $this->assertSame(true, $bnode1->isBNode());
+        $this->assertTrue($bnode1->isBNode());
         $this->assertStringEquals('_:genid2', $bnode1->get('<http://example.com/a>'));
 
         $bnode2 = $this->graph->resource('_:genid3');
-        $this->assertSame(true, $bnode2->isBNode());
+        $this->assertTrue($bnode2->isBNode());
         $this->assertStringEquals('_:genid4', $bnode2->get('<http://example.com/b>'));
     }
 
@@ -131,7 +132,7 @@ class NtriplesTest extends TestCase
         $this->assertNotNull($int);
         $this->assertSame('English', $int->getValue());
         $this->assertSame('en-gb', $int->getLang());
-        $this->assertSame(null, $int->getDatatype());
+        $this->assertNull($int->getDatatype());
     }
 
     public function testParseDatatype()
@@ -147,7 +148,7 @@ class NtriplesTest extends TestCase
         $int = $this->graph->get('http://example.com/a', '<http://example.com/b>');
         $this->assertNotNull($int);
         $this->assertSame(1, $int->getValue());
-        $this->assertSame(null, $int->getLang());
+        $this->assertNull($int->getLang());
         $this->assertSame('xsd:integer', $int->getDatatype());
     }
 
@@ -196,7 +197,7 @@ class NtriplesTest extends TestCase
 
         $a = $this->graph->resource('http://example.com/a');
         $b = $a->get('<http://example.com/b>');
-        $this->assertSame("http://example.com/Iván", $b->getUri());
+        $this->assertSame('http://example.com/Iván', $b->getUri());
     }
 
     public function testParseUnicodeSubjectUri()
@@ -225,7 +226,7 @@ class NtriplesTest extends TestCase
 
         $a = $this->graph->resource('http://example.com/a');
         $b = $a->get('<http://example.com/b>');
-        $this->assertSame("Iván", $b->getValue());
+        $this->assertSame('Iván', $b->getValue());
     }
 
     public function testParseUnicode3()
@@ -240,7 +241,7 @@ class NtriplesTest extends TestCase
 
         $a = $this->graph->resource('http://example.com/a');
         $b = $a->get('<http://example.com/b>');
-        $this->assertSame("Δ", $b->getValue());
+        $this->assertSame('Δ', $b->getValue());
     }
 
     public function testParseUnicode4()
@@ -255,7 +256,7 @@ class NtriplesTest extends TestCase
 
         $a = $this->graph->resource('http://example.com/a');
         $b = $a->get('<http://example.com/b>');
-        $this->assertSame("☃", $b->getValue());
+        $this->assertSame('☃', $b->getValue());
     }
 
     public function testParseUnicode5()
@@ -270,7 +271,7 @@ class NtriplesTest extends TestCase
 
         $a = $this->graph->resource('http://example.com/a');
         $b = $a->get('<http://example.com/b>');
-        $this->assertSame("😀", $b->getValue());
+        $this->assertSame('😀', $b->getValue());
     }
 
     public function testParseUnicode6()
@@ -285,7 +286,7 @@ class NtriplesTest extends TestCase
 
         $a = $this->graph->resource('http://example.com/a');
         $b = $a->get('<http://example.com/b>');
-        $this->assertSame("", $b->getValue());
+        $this->assertSame('', $b->getValue());
     }
 
     public function testParseComment()
@@ -312,7 +313,7 @@ class NtriplesTest extends TestCase
             "  \r\n".
             "\r\n".
             "<http://example.com/c> <http://example.com/c> \"Test 2\" .\n".
-            "    ",
+            '    ',
             'ntriples',
             null
         );

--- a/test/EasyRdf/Parser/RapperTest.php
+++ b/test/EasyRdf/Parser/RapperTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Parser;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -39,8 +40,8 @@ namespace EasyRdf\Parser;
 use EasyRdf\Graph;
 use EasyRdf\TestCase;
 
-require_once dirname(dirname(__DIR__)).
-             DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(\dirname(__DIR__)).
+             \DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class RapperTest extends TestCase
 {
@@ -53,13 +54,13 @@ class RapperTest extends TestCase
     public function setUp()
     {
         exec('rapper --version 2>/dev/null', $output, $retval);
-        if ($retval == 0) {
+        if (0 == $retval) {
             $this->parser = new Rapper();
             $this->graph = new Graph();
             $this->rdf_data = readFixture('foaf.rdf');
         } else {
             $this->markTestSkipped(
-                "The rapper command is not available on this system."
+                'The rapper command is not available on this system.'
             );
         }
     }
@@ -77,7 +78,7 @@ class RapperTest extends TestCase
     {
         $this->setExpectedException(
             'EasyRdf\Exception',
-            "Version 1.4.17 or higher of rapper is required."
+            'Version 1.4.17 or higher of rapper is required.'
         );
         new Rapper('echo 1.0.0');
     }
@@ -102,7 +103,7 @@ class RapperTest extends TestCase
         $this->assertClass('EasyRdf\Literal', $name);
         $this->assertStringEquals('Joe Bloggs', $name);
         $this->assertSame('en', $name->getLang());
-        $this->assertSame(null, $name->getDatatype());
+        $this->assertNull($name->getDatatype());
 
         $foaf = $this->graph->resource('http://www.example.com/joe/foaf.rdf');
         $this->assertNotNull($foaf);

--- a/test/EasyRdf/Parser/RdfPhpTest.php
+++ b/test/EasyRdf/Parser/RdfPhpTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Parser;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -39,8 +40,8 @@ namespace EasyRdf\Parser;
 use EasyRdf\Graph;
 use EasyRdf\TestCase;
 
-require_once dirname(dirname(__DIR__)).
-             DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(\dirname(__DIR__)).
+             \DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class RdfPhpTest extends TestCase
 {
@@ -54,17 +55,17 @@ class RdfPhpTest extends TestCase
     {
         $this->graph = new Graph();
         $this->parser = new RdfPhp();
-        $this->rdf_data = array(
-            'http://example.com/joe' => array(
-                'http://xmlns.com/foaf/0.1/name' => array(
-                    array(
+        $this->rdf_data = [
+            'http://example.com/joe' => [
+                'http://xmlns.com/foaf/0.1/name' => [
+                    [
                         'type' => 'literal',
                         'value' => 'Joseph Bloggs',
-                        'lang' => 'en'
-                    )
-                )
-            )
-        );
+                        'lang' => 'en',
+                    ],
+                ],
+            ],
+        ];
     }
 
     public function testParse()
@@ -83,7 +84,7 @@ class RdfPhpTest extends TestCase
         $this->assertClass('EasyRdf\Literal', $name);
         $this->assertSame('Joseph Bloggs', $name->getValue());
         $this->assertSame('en', $name->getLang());
-        $this->assertSame(null, $name->getDatatype());
+        $this->assertNull($name->getDatatype());
     }
 
     public function testParseTwice()
@@ -97,12 +98,12 @@ class RdfPhpTest extends TestCase
     public function testParseDuplicateBNodes()
     {
         $foafName = 'http://xmlns.com/foaf/0.1/name';
-        $bnodeA = array( '_:genid1' => array(
-            $foafName => array(array( 'type' => 'literal', 'value' => 'A' ))
-        ));
-        $bnodeB = array( '_:genid1' => array(
-            $foafName => array(array( 'type' => 'literal', 'value' => 'B' ))
-        ));
+        $bnodeA = ['_:genid1' => [
+            $foafName => [['type' => 'literal', 'value' => 'A']],
+        ]];
+        $bnodeB = ['_:genid1' => [
+            $foafName => [['type' => 'literal', 'value' => 'B']],
+        ]];
 
         $this->parser->parse($this->graph, $bnodeA, 'php', null);
         $this->parser->parse($this->graph, $bnodeB, 'php', null);
@@ -133,7 +134,8 @@ class RdfPhpTest extends TestCase
 
     /**
      * 'foo' is not a valid input for RdfPhp
-     * @expectedException Exception
+     *
+     * @expectedException \Exception
      */
     public function testParseInvalidInput1()
     {
@@ -142,38 +144,42 @@ class RdfPhpTest extends TestCase
 
     /**
      * list of strings is not a valid input for RdfPhp
-     * @expectedException Exception
+     *
+     * @expectedException \Exception
      */
     public function testParseInvalidInput2()
     {
-        $this->parser->parse($this->graph, array('foo', 'bar'), 'php', null);
+        $this->parser->parse($this->graph, ['foo', 'bar'], 'php', null);
     }
 
     /**
      * 1-level dictionary of strings is not a valid input for RdfPhp
-     * @expectedException Exception
+     *
+     * @expectedException \Exception
      */
     public function testParseInvalidInput3()
     {
-        $this->parser->parse($this->graph, array('foo' => 'bar'), 'php', null);
+        $this->parser->parse($this->graph, ['foo' => 'bar'], 'php', null);
     }
 
     /**
      * 2-level dictionary of strings is not a valid input for RdfPhp
-     * @expectedException Exception
+     *
+     * @expectedException \Exception
      */
     public function testParseInvalidInput4()
     {
-        $this->parser->parse($this->graph, array('foo' => array('bar' => 'baz')), 'php', null);
+        $this->parser->parse($this->graph, ['foo' => ['bar' => 'baz']], 'php', null);
     }
 
     /**
      * 2-level dictionary of incorrect arrays is not a valid input for RdfPhp
-     * @expectedException Exception
+     *
+     * @expectedException \Exception
      */
     public function testParseInvalidInput5()
     {
-        $this->parser->parse($this->graph, array('foo' => array('bar' => array('baz' => 'buzz'))), 'php', null);
+        $this->parser->parse($this->graph, ['foo' => ['bar' => ['baz' => 'buzz']]], 'php', null);
     }
 
     /**

--- a/test/EasyRdf/Parser/RdfXmlTest.php
+++ b/test/EasyRdf/Parser/RdfXmlTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Parser;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -39,8 +40,8 @@ namespace EasyRdf\Parser;
 use EasyRdf\Graph;
 use EasyRdf\TestCase;
 
-require_once dirname(dirname(__DIR__)).
-             DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(\dirname(__DIR__)).
+             \DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class RdfXmlTest extends TestCase
 {
@@ -77,7 +78,7 @@ class RdfXmlTest extends TestCase
         $this->assertClass('EasyRdf\Literal', $name);
         $this->assertStringEquals('Joe Bloggs', $name);
         $this->assertSame('en', $name->getLang());
-        $this->assertSame(null, $name->getDatatype());
+        $this->assertNull($name->getDatatype());
 
         $foaf = $this->graph->resource('http://www.example.com/joe/foaf.rdf');
         $this->assertNotNull($foaf);
@@ -114,7 +115,7 @@ class RdfXmlTest extends TestCase
             "  <rdf:Description rdf:about='http://example.org/foo'>\n".
             "    <rdf:foo>Hello World\n".
             "  </rdf:Description>\n".
-            "</rdf:RDF>",
+            '</rdf:RDF>',
             'rdfxml',
             'http://example.org/'
         );

--- a/test/EasyRdf/Parser/RdfaTest.php
+++ b/test/EasyRdf/Parser/RdfaTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Parser;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -39,8 +40,8 @@ namespace EasyRdf\Parser;
 use EasyRdf\Graph;
 use EasyRdf\TestCase;
 
-require_once dirname(dirname(__DIR__)).
-             DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(\dirname(__DIR__)).
+             \DIRECTORY_SEPARATOR.'TestHelper.php';
 
 require_once realpath(__DIR__.'/..').'/Serialiser/NtriplesArray.php';
 
@@ -60,7 +61,6 @@ class RdfaTest extends TestCase
         $this->baseUri = 'http://rdfa.info/test-suite/test-cases/rdfa1.1/xhtml5/';
     }
 
-
     protected function parseRdfa($filename)
     {
         $graph = new Graph();
@@ -68,8 +68,9 @@ class RdfaTest extends TestCase
             $graph,
             readFixture($filename),
             'rdfa',
-            $this->baseUri . basename($filename)
+            $this->baseUri.basename($filename)
         );
+
         return $graph->serialise('ntriples-array');
     }
 
@@ -80,8 +81,9 @@ class RdfaTest extends TestCase
             $graph,
             readFixture($filename),
             'ntriples',
-            $this->baseUri . basename($filename)
+            $this->baseUri.basename($filename)
         );
+
         return $graph->serialise('ntriples-array');
     }
 
@@ -602,7 +604,7 @@ class RdfaTest extends TestCase
 
     public function testCase0224()
     {
-        $this->markTestIncomplete("FIXME: need to implement @inlist");
+        $this->markTestIncomplete('FIXME: need to implement @inlist');
         $this->rdfaTestCase('0224', '@inlist hanging @rel');
     }
 
@@ -647,7 +649,7 @@ class RdfaTest extends TestCase
 
     public function testCase0247()
     {
-        $this->markTestIncomplete("FIXME: Multiple incomplete triples, RDFa 1.1version");
+        $this->markTestIncomplete('FIXME: Multiple incomplete triples, RDFa 1.1version');
         $this->rdfaTestCase('0247', 'Multiple incomplete triples, RDFa 1.1version');
     }
 
@@ -909,7 +911,7 @@ class RdfaTest extends TestCase
 
     public function testCase0312()
     {
-        $this->markTestIncomplete("FIXME: Mute plain @rel if @property is present");
+        $this->markTestIncomplete('FIXME: Mute plain @rel if @property is present');
         $this->rdfaTestCase('0312', 'Mute plain @rel if @property is present');
     }
 
@@ -940,43 +942,43 @@ class RdfaTest extends TestCase
 
     public function testCase0321()
     {
-        $this->markTestIncomplete("FIXME: rdfa:copy to rdfa:Pattern");
+        $this->markTestIncomplete('FIXME: rdfa:copy to rdfa:Pattern');
         $this->rdfaTestCase('0321', 'rdfa:copy to rdfa:Pattern');
     }
 
     public function testCase0322()
     {
-        $this->markTestIncomplete("FIXME: rdfa:copy for additional property value");
+        $this->markTestIncomplete('FIXME: rdfa:copy for additional property value');
         $this->rdfaTestCase('0322', 'rdfa:copy for additional property value');
     }
 
     public function testCase0323()
     {
-        $this->markTestIncomplete("FIXME: Multiple references to rdfa:Pattern");
+        $this->markTestIncomplete('FIXME: Multiple references to rdfa:Pattern');
         $this->rdfaTestCase('0323', 'Multiple references to rdfa:Pattern');
     }
 
     public function testCase0324()
     {
-        $this->markTestIncomplete("FIXME: Multiple references to rdfa:Pattern");
+        $this->markTestIncomplete('FIXME: Multiple references to rdfa:Pattern');
         $this->rdfaTestCase('0324', 'Multiple references to rdfa:Pattern');
     }
 
     public function testCase0325()
     {
-        $this->markTestIncomplete("FIXME: Multiple references to rdfa:Pattern creating a resource");
+        $this->markTestIncomplete('FIXME: Multiple references to rdfa:Pattern creating a resource');
         $this->rdfaTestCase('0325', 'Multiple references to rdfa:Pattern creating a resource');
     }
 
     public function testCase0326()
     {
-        $this->markTestIncomplete("FIXME: rdfa:Pattern removed only if referenced");
+        $this->markTestIncomplete('FIXME: rdfa:Pattern removed only if referenced');
         $this->rdfaTestCase('0326', 'rdfa:Pattern removed only if referenced');
     }
 
     public function testCase0327()
     {
-        $this->markTestIncomplete("FIXME: rdfa:Pattern chaining");
+        $this->markTestIncomplete('FIXME: rdfa:Pattern chaining');
         $this->rdfaTestCase('0327', 'rdfa:Pattern chaining');
     }
 

--- a/test/EasyRdf/Parser/TurtleTest.php
+++ b/test/EasyRdf/Parser/TurtleTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Parser;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -39,8 +40,8 @@ namespace EasyRdf\Parser;
 use EasyRdf\Graph;
 use EasyRdf\TestCase;
 
-require_once dirname(dirname(__DIR__)).
-             DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(\dirname(__DIR__)).
+             \DIRECTORY_SEPARATOR.'TestHelper.php';
 
 require_once realpath(__DIR__.'/..').'/Serialiser/NtriplesArray.php';
 
@@ -81,7 +82,7 @@ class TurtleTest extends TestCase
         $this->assertClass('EasyRdf\Literal', $name);
         $this->assertStringEquals('Joe Bloggs', $name);
         $this->assertSame('en', $name->getLang());
-        $this->assertSame(null, $name->getDatatype());
+        $this->assertNull($name->getDatatype());
 
         $foaf = $graph->resource('http://www.example.com/joe/foaf.rdf');
         $this->assertNotNull($foaf);
@@ -99,14 +100,14 @@ class TurtleTest extends TestCase
         );
         $this->assertSame(9, $count);
 
-        $array = array();
+        $array = [];
         $collection = $graph->resource('http://example.com/s')->get('<http://example.com/p>');
         foreach ($collection as $item) {
-            $array[] = strval($item);
+            $array[] = (string) $item;
         }
 
         $this->assertEquals(
-            array('A', 'B', 'C', 'D'),
+            ['A', 'B', 'C', 'D'],
             $array
         );
     }
@@ -137,8 +138,9 @@ class TurtleTest extends TestCase
             $graph,
             readFixture($filename),
             'turtle',
-            $this->baseUri . basename($filename)
+            $this->baseUri.basename($filename)
         );
+
         return $graph->serialise('ntriples-array');
     }
 
@@ -149,8 +151,9 @@ class TurtleTest extends TestCase
             $graph,
             readFixture($filename),
             'ntriples',
-            $this->baseUri . basename($filename)
+            $this->baseUri.basename($filename)
         );
+
         return $graph->serialise('ntriples-array');
     }
 
@@ -164,85 +167,85 @@ class TurtleTest extends TestCase
 
     public function testCase00()
     {
-        # Blank subject
+        // Blank subject
         $this->turtleTestCase('test-00');
     }
 
     public function testCase01()
     {
-        # @prefix and qnames
+        // @prefix and qnames
         $this->turtleTestCase('test-01');
     }
 
     public function testCase02()
     {
-        # , operator
+        // , operator
         $this->turtleTestCase('test-02');
     }
 
     public function testCase03()
     {
-        # ; operator
+        // ; operator
         $this->turtleTestCase('test-03');
     }
 
     public function testCase04()
     {
-        # empty [] as subject and object
+        // empty [] as subject and object
         $this->turtleTestCase('test-04');
     }
 
     public function testCase05()
     {
-        # non-empty [] as subject and object
+        // non-empty [] as subject and object
         $this->turtleTestCase('test-05');
     }
 
     public function testCase06()
     {
-        # 'a' as predicate
+        // 'a' as predicate
         $this->turtleTestCase('test-06');
     }
 
     public function testCase07()
     {
-        # simple collection
+        // simple collection
         $this->turtleTestCase('test-07');
     }
 
     public function testCase08()
     {
-        # empty collection
+        // empty collection
         $this->turtleTestCase('test-08');
     }
 
     public function testCase09()
     {
-        # integer datatyped literal
+        // integer datatyped literal
         $this->turtleTestCase('test-09');
     }
 
     public function testCase10()
     {
-        # decimal integer canonicalization
+        // decimal integer canonicalization
         $this->turtleTestCase('test-10');
     }
 
     public function testCase11()
     {
-        # - and _ in names and qnames
+        // - and _ in names and qnames
         $this->turtleTestCase('test-11');
     }
 
     public function testCase12()
     {
-        # tests for rdf:_<numbers> and other qnames starting with _
+        // tests for rdf:_<numbers> and other qnames starting with _
         $this->turtleTestCase('test-12');
     }
 
     public function testCase13()
     {
-        # bare : allowed
+        // bare : allowed
         $this->turtleTestCase('test-13');
     }
 
@@ -250,67 +253,67 @@ class TurtleTest extends TestCase
 
     public function testCase17()
     {
-        # simple long literal
+        // simple long literal
         $this->turtleTestCase('test-17');
     }
 
     public function testCase18()
     {
-        # long literals with escapes
+        // long literals with escapes
         $this->turtleTestCase('test-18');
     }
 
     public function testCase19()
     {
-        # floating point number
+        // floating point number
         $this->turtleTestCase('test-19');
     }
 
     public function testCase20()
     {
-        # empty literals, normal and long variant
+        // empty literals, normal and long variant
         $this->turtleTestCase('test-20');
     }
 
     public function testCase21()
     {
-        # positive integer, decimal and doubles
+        // positive integer, decimal and doubles
         $this->turtleTestCase('test-21');
     }
 
     public function testCase22()
     {
-        # negative integer, decimal and doubles
+        // negative integer, decimal and doubles
         $this->turtleTestCase('test-22');
     }
 
     public function testCase23()
     {
-        # long literal ending in double quote
+        // long literal ending in double quote
         $this->turtleTestCase('test-23');
     }
 
     public function testCase24()
     {
-        # boolean literals
+        // boolean literals
         $this->turtleTestCase('test-24');
     }
 
     public function testCase25()
     {
-        # comments
+        // comments
         $this->turtleTestCase('test-25');
     }
 
     public function testCase26()
     {
-        # no final newline
+        // no final newline
         $this->turtleTestCase('test-26');
     }
 
     public function testCase27()
     {
-        # duplicate prefix
+        // duplicate prefix
         $this->turtleTestCase('test-27');
     }
 
@@ -331,7 +334,7 @@ class TurtleTest extends TestCase
 
     public function testBase1()
     {
-        # Resolution of a relative URI against an absolute base.
+        // Resolution of a relative URI against an absolute base.
         $this->turtleTestCase('base1');
     }
 
@@ -347,152 +350,152 @@ class TurtleTest extends TestCase
 
     public function testBad00()
     {
-        # prefix name must end in a :
+        // prefix name must end in a :
         $this->setExpectedException(
             'EasyRdf\Parser\Exception',
             "Turtle Parse Error: expected ':', found '<' on line 2, column 12"
         );
-        $this->parseTurtle("turtle/bad-00.ttl");
+        $this->parseTurtle('turtle/bad-00.ttl');
     }
 
     public function testBad01()
     {
-        # Forbidden by RDF - predicate cannot be blank
+        // Forbidden by RDF - predicate cannot be blank
         $this->setExpectedException(
             'EasyRdf\Parser\Exception',
             "Turtle Parse Error: expected an RDF value here, found '[' on line 3, column 4"
         );
-        $this->parseTurtle("turtle/bad-01.ttl");
+        $this->parseTurtle('turtle/bad-01.ttl');
     }
 
     public function testBad02()
     {
-        # Forbidden by RDF - predicate cannot be blank
+        // Forbidden by RDF - predicate cannot be blank
         $this->setExpectedException(
             'EasyRdf\Parser\Exception',
             "Turtle Parse Error: expected an RDF value here, found '[' on line 3, column 4"
         );
-        $this->parseTurtle("turtle/bad-02.ttl");
+        $this->parseTurtle('turtle/bad-02.ttl');
     }
 
     public function testBad03()
     {
-        # 'a' only allowed as a predicate
+        // 'a' only allowed as a predicate
         $this->setExpectedException(
             'EasyRdf\Parser\Exception',
             "Turtle Parse Error: expected ':', found ' ' on line 3, column 3"
         );
-        $this->parseTurtle("turtle/bad-03.ttl");
+        $this->parseTurtle('turtle/bad-03.ttl');
     }
 
     public function testBad04()
     {
-        # No comma is allowed in collections
+        // No comma is allowed in collections
         $this->setExpectedException(
             'EasyRdf\Parser\Exception',
             "Turtle Parse Error: expected an RDF value here, found ',' on line 3, column 16"
         );
-        $this->parseTurtle("turtle/bad-04.ttl");
+        $this->parseTurtle('turtle/bad-04.ttl');
     }
 
     public function testBad05()
     {
-        # N3 {}s are not in Turtle
+        // N3 {}s are not in Turtle
         $this->setExpectedException(
             'EasyRdf\Parser\Exception',
             "Turtle Parse Error: expected an RDF value here, found '{' on line 3, column 1"
         );
-        $this->parseTurtle("turtle/bad-05.ttl");
+        $this->parseTurtle('turtle/bad-05.ttl');
     }
 
     public function testBad06()
     {
-        # is and of are not in turtle
+        // is and of are not in turtle
         $this->setExpectedException(
             'EasyRdf\Parser\Exception',
             "Turtle Parse Error: expected ':', found ' ' on line 3, column 7"
         );
-        $this->parseTurtle("turtle/bad-06.ttl");
+        $this->parseTurtle('turtle/bad-06.ttl');
     }
 
     public function testBad07()
     {
-        # paths are not in turtle
+        // paths are not in turtle
         $this->setExpectedException(
             'EasyRdf\Parser\Exception',
-            "Turtle Parse Error: object for statement missing on line 3, column 5"
+            'Turtle Parse Error: object for statement missing on line 3, column 5'
         );
-        $this->parseTurtle("turtle/bad-07.ttl");
+        $this->parseTurtle('turtle/bad-07.ttl');
     }
 
     public function testBad08()
     {
-        # @keywords is not in turtle
+        // @keywords is not in turtle
         $this->setExpectedException(
             'EasyRdf\Parser\Exception',
             'Turtle Parse Error: unknown directive "@keywords" on line 1, column 10'
         );
-        $this->parseTurtle("turtle/bad-08.ttl");
+        $this->parseTurtle('turtle/bad-08.ttl');
     }
 
     public function testBad09()
     {
-        # implies is not in turtle
+        // implies is not in turtle
         $this->setExpectedException(
             'EasyRdf\Parser\Exception',
             "Turtle Parse Error: expected an RDF value here, found '=' on line 3, column 4"
         );
-        $this->parseTurtle("turtle/bad-09.ttl");
+        $this->parseTurtle('turtle/bad-09.ttl');
     }
 
     public function testBad10()
     {
-        # equivalence is not in turtle
+        // equivalence is not in turtle
         $this->setExpectedException(
             'EasyRdf\Parser\Exception',
             "Turtle Parse Error: expected an RDF value here, found '=' on line 3, column 4"
         );
-        $this->parseTurtle("turtle/bad-10.ttl");
+        $this->parseTurtle('turtle/bad-10.ttl');
     }
 
     public function testBad11()
     {
-        # @forAll is not in turtle
+        // @forAll is not in turtle
         $this->setExpectedException(
             'EasyRdf\Parser\Exception',
-            "Turtle Parse Error: unknown directive \"@forall\" on line 3, column 8"
+            'Turtle Parse Error: unknown directive "@forall" on line 3, column 8'
         );
-        $this->parseTurtle("turtle/bad-11.ttl");
+        $this->parseTurtle('turtle/bad-11.ttl');
     }
 
     public function testBad12()
     {
-        # @forSome is not in turtle
+        // @forSome is not in turtle
         $this->setExpectedException(
             'EasyRdf\Parser\Exception',
-            "Turtle Parse Error: unknown directive \"@forsome\" on line 3, column 9"
+            'Turtle Parse Error: unknown directive "@forsome" on line 3, column 9'
         );
-        $this->parseTurtle("turtle/bad-12.ttl");
+        $this->parseTurtle('turtle/bad-12.ttl');
     }
 
     public function testBad13()
     {
-        # <= is not in turtle
+        // <= is not in turtle
         $this->setExpectedException(
             'EasyRdf\Parser\Exception',
-            "Turtle Parse Error: unexpected end of file while reading URI on line 4, column 1"
+            'Turtle Parse Error: unexpected end of file while reading URI on line 4, column 1'
         );
-        $this->parseTurtle("turtle/bad-13.ttl");
+        $this->parseTurtle('turtle/bad-13.ttl');
     }
 
     public function testBad14()
     {
-        # Test long literals with missing end
+        // Test long literals with missing end
         $this->setExpectedException(
             'EasyRdf\Parser\Exception',
-            "Turtle Parse Error: unexpected end of file while reading long string on line 7, column 1"
+            'Turtle Parse Error: unexpected end of file while reading long string on line 7, column 1'
         );
-        $this->parseTurtle("turtle/bad-14.ttl");
+        $this->parseTurtle('turtle/bad-14.ttl');
     }
 
     /**
@@ -507,7 +510,7 @@ class TurtleTest extends TestCase
             $graph,
             readFixture($filename),
             'turtle',
-            $this->baseUri . basename($filename)
+            $this->baseUri.basename($filename)
         );
 
         $this->assertEquals(1, $triple_count);
@@ -525,7 +528,7 @@ class TurtleTest extends TestCase
             $graph,
             readFixture($filename),
             'turtle',
-            $this->baseUri . basename($filename)
+            $this->baseUri.basename($filename)
         );
 
         $this->assertEquals(1, $triple_count);
@@ -556,7 +559,7 @@ class TurtleTest extends TestCase
             $graph,
             readFixture($filename),
             'turtle',
-            $this->baseUri . basename($filename)
+            $this->baseUri.basename($filename)
         );
 
         $this->assertEquals(14, $triple_count);

--- a/test/EasyRdf/ParserTest.php
+++ b/test/EasyRdf/ParserTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EasyRdf;
 
 /**
@@ -31,12 +32,10 @@ namespace EasyRdf;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
-
-require_once dirname(__DIR__).DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(__DIR__).\DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class MockParser extends Parser
 {

--- a/test/EasyRdf/ResourceTest.php
+++ b/test/EasyRdf/ResourceTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -38,7 +39,7 @@ namespace EasyRdf;
 
 use EasyRdf\Http\MockClient;
 
-require_once dirname(__DIR__).DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(__DIR__).\DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class ResourceTest extends TestCase
 {
@@ -81,7 +82,7 @@ class ResourceTest extends TestCase
             'InvalidArgumentException',
             '$uri should be a string and cannot be null or empty'
         );
-        new Resource(array());
+        new Resource([]);
     }
 
     public function testConstructBadGraph()
@@ -105,13 +106,13 @@ class ResourceTest extends TestCase
     public function testIsBNode()
     {
         $bnode = new Resource('_:foobar');
-        $this->assertSame(true, $bnode->isBNode());
+        $this->assertTrue($bnode->isBNode());
     }
 
     public function testIsNotBnode()
     {
         $nonbnode = new Resource('http://www.exaple.com/');
-        $this->assertSame(false, $nonbnode->isBNode());
+        $this->assertFalse($nonbnode->isBNode());
     }
 
     public function testGetBNodeId()
@@ -123,7 +124,7 @@ class ResourceTest extends TestCase
     public function testGetBNodeIdForUri()
     {
         $nonbnode = new Resource('http://www.exaple.com/');
-        $this->assertSame(null, $nonbnode->getBNodeId());
+        $this->assertNull($nonbnode->getBNodeId());
     }
 
     public function testPrefix()
@@ -147,7 +148,7 @@ class ResourceTest extends TestCase
     public function testShortenUnknown()
     {
         $unknown = new Resource('http://example.com/foo');
-        $this->assertSame(null, $unknown->shorten());
+        $this->assertNull($unknown->shorten());
     }
 
     public function testLocalnameWithSlash()
@@ -171,7 +172,7 @@ class ResourceTest extends TestCase
     public function testLocalnameWithNoPath()
     {
         $res = new Resource('http://example.com/');
-        $this->assertSame(null, $res->localName());
+        $this->assertNull($res->localName());
     }
 
     public function testParseUri()
@@ -202,7 +203,7 @@ class ResourceTest extends TestCase
         $res = new Resource('http://example.com/');
         $this->assertSame(
             '<a href="http://example.com/" style="font-weight: bold">Click Here</a>',
-            $res->htmlLink('Click Here', array('style' => 'font-weight: bold'))
+            $res->htmlLink('Click Here', ['style' => 'font-weight: bold'])
         );
     }
 
@@ -223,14 +224,14 @@ class ResourceTest extends TestCase
         );
 
         $res = new Resource('http://example.com/');
-        $res->htmlLink(null, array('onclick=alert(1) a' => 'b"'));
+        $res->htmlLink(null, ['onclick=alert(1) a' => 'b"']);
     }
 
     public function testToRdfPhpForUri()
     {
         $uri = new Resource('http://www.example.com/');
         $this->assertSame(
-            array('type' => 'uri', 'value' => 'http://www.example.com/'),
+            ['type' => 'uri', 'value' => 'http://www.example.com/'],
             $uri->toRdfPhp()
         );
     }
@@ -239,7 +240,7 @@ class ResourceTest extends TestCase
     {
         $bnode = new Resource('_:foobar');
         $this->assertSame(
-            array('type' => 'bnode', 'value' => '_:foobar'),
+            ['type' => 'bnode', 'value' => '_:foobar'],
             $bnode->toRdfPhp()
         );
     }
@@ -248,13 +249,13 @@ class ResourceTest extends TestCase
     {
         $res = new Resource('http://www.example.com/');
         $this->assertSame(
-            "http://www.example.com/",
+            'http://www.example.com/',
             $res->dumpValue('text')
         );
         $this->assertSame(
             "<a href='http://www.example.com/' ".
             "style='text-decoration:none;color:blue'>".
-            "http://www.example.com/</a>",
+            'http://www.example.com/</a>',
             $res->dumpValue('html')
         );
     }
@@ -265,7 +266,7 @@ class ResourceTest extends TestCase
         $this->assertSame(
             "<a href='http://www.example.com/' ".
             "style='text-decoration:none;color:red'>".
-            "http://www.example.com/</a>",
+            'http://www.example.com/</a>',
             $res->dumpValue('html', 'red')
         );
     }
@@ -275,9 +276,6 @@ class ResourceTest extends TestCase
         $res = new Resource('http://example.com/testToString');
         $this->assertStringEquals('http://example.com/testToString', $res);
     }
-
-
-
 
     /*
      *
@@ -530,7 +528,7 @@ class ResourceTest extends TestCase
     {
         $this->setupTestGraph();
         $this->assertSame(
-            array(),
+            [],
             $this->resource->all('foo:bar')
         );
     }
@@ -562,7 +560,7 @@ class ResourceTest extends TestCase
             'InvalidArgumentException',
             '$propertyPath should be a string or EasyRdf\Resource and cannot be null'
         );
-        $this->resource->all(array());
+        $this->resource->all([]);
     }
 
     public function testAllLiterals()
@@ -578,7 +576,7 @@ class ResourceTest extends TestCase
     {
         $this->setupTestGraph();
         $all = $this->resource->allLiterals('rdf:type');
-        $this->assertTrue(is_array($all));
+        $this->assertTrue(\is_array($all));
         $this->assertCount(0, $all);
     }
 
@@ -639,7 +637,7 @@ class ResourceTest extends TestCase
         $title = $this->resource->get('dc:title');
         $this->assertSame('English Title', $title->getValue());
         $this->assertSame('en', $title->getLang());
-        $this->assertSame(null, $title->getDataType());
+        $this->assertNull($title->getDataType());
     }
 
     public function testAddResource()
@@ -654,7 +652,7 @@ class ResourceTest extends TestCase
     public function testAddMultipleLiterals()
     {
         $this->setupTestGraph();
-        $count = $this->resource->addLiteral('rdf:test', array('Test C', 'Test D'));
+        $count = $this->resource->addLiteral('rdf:test', ['Test C', 'Test D']);
         $this->assertSame(2, $count);
         $all = $this->resource->all('rdf:test');
         $this->assertCount(4, $all);
@@ -727,7 +725,7 @@ class ResourceTest extends TestCase
             'InvalidArgumentException',
             '$property should be a string or EasyRdf\Resource and cannot be null'
         );
-        $this->resource->add(array(), 'Test C');
+        $this->resource->add([], 'Test C');
     }
 
     public function testAddInvalidObject()
@@ -750,7 +748,7 @@ class ResourceTest extends TestCase
         $this->setupTestGraph();
         $this->assertStringEquals('Test A', $this->resource->get('rdf:test'));
         $this->resource->delete('rdf:test');
-        $this->assertSame(array(), $this->resource->all('rdf:test'));
+        $this->assertSame([], $this->resource->all('rdf:test'));
     }
 
     public function testDeleteWithUri()
@@ -760,7 +758,7 @@ class ResourceTest extends TestCase
         $this->resource->delete(
             'http://www.w3.org/1999/02/22-rdf-syntax-ns#test'
         );
-        $this->assertSame(array(), $this->resource->all('rdf:test'));
+        $this->assertSame([], $this->resource->all('rdf:test'));
     }
 
     public function testDeleteNullKey()
@@ -790,7 +788,7 @@ class ResourceTest extends TestCase
             'InvalidArgumentException',
             '$property should be a string or EasyRdf\Resource and cannot be null'
         );
-        $this->resource->delete(array());
+        $this->resource->delete([]);
     }
 
     public function testDeleteValue()
@@ -836,15 +834,13 @@ class ResourceTest extends TestCase
             $this->resource,
             $homepage1->get('^foaf:homepage')
         );
-        $this->assertSame(
-            null,
+        $this->assertNull(
             $homepage2->get('^foaf:homepage')
         );
 
         $count = $this->resource->set('foaf:homepage', $homepage2);
         $this->assertSame(1, $count);
-        $this->assertSame(
-            null,
+        $this->assertNull(
             $homepage1->get('^foaf:homepage')
         );
         $this->assertSame(
@@ -880,7 +876,7 @@ class ResourceTest extends TestCase
             'InvalidArgumentException',
             '$property should be a string or EasyRdf\Resource and cannot be null'
         );
-        $this->resource->set(array(), 'Test C');
+        $this->resource->set([], 'Test C');
     }
 
     public function testSetNull()
@@ -889,7 +885,7 @@ class ResourceTest extends TestCase
         $count = $this->resource->set('rdf:test', null);
         $this->assertSame(0, $count);
         $this->assertSame(
-            array(),
+            [],
             $this->resource->all('rdf:test')
         );
     }
@@ -987,14 +983,14 @@ class ResourceTest extends TestCase
             'InvalidArgumentException',
             '$propertyPath should be a string or EasyRdf\Resource and cannot be null'
         );
-        $this->resource->join(array(), 'Test C');
+        $this->resource->join([], 'Test C');
     }
 
     public function testProperties()
     {
         $this->setupTestGraph();
         $this->assertSame(
-            array('rdf:type', 'rdf:test'),
+            ['rdf:type', 'rdf:test'],
             $this->resource->properties()
         );
     }
@@ -1003,10 +999,10 @@ class ResourceTest extends TestCase
     {
         $this->setupTestGraph();
         $this->assertSame(
-            array(
+            [
                 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
-                'http://www.w3.org/1999/02/22-rdf-syntax-ns#test'
-            ),
+                'http://www.w3.org/1999/02/22-rdf-syntax-ns#test',
+            ],
             $this->resource->propertyUris()
         );
     }
@@ -1015,9 +1011,9 @@ class ResourceTest extends TestCase
     {
         $this->setupTestGraph();
         $this->assertSame(
-            array(
-                'http://www.w3.org/1999/02/22-rdf-syntax-ns#type'
-            ),
+            [
+                'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
+            ],
             $this->type->reversePropertyUris()
         );
     }
@@ -1202,7 +1198,7 @@ class ResourceTest extends TestCase
         $this->assertContains(
             "<a href='http://example.com/#me' ".
             "style='text-decoration:none;color:blue'>".
-            "http://example.com/#me</a>",
+            'http://example.com/#me</a>',
             $html
         );
         $this->assertContains(

--- a/test/EasyRdf/Serialiser/ArcTest.php
+++ b/test/EasyRdf/Serialiser/ArcTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Serialiser;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -39,8 +40,8 @@ namespace EasyRdf\Serialiser;
 use EasyRdf\Graph;
 use EasyRdf\TestCase;
 
-require_once dirname(dirname(dirname(__FILE__))).
-             DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(\dirname(__DIR__)).
+             \DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class ArcTest extends TestCase
 {
@@ -57,7 +58,7 @@ class ArcTest extends TestCase
             parent::setUp();
         } else {
             $this->markTestSkipped(
-                "ARC2 library is not available."
+                'ARC2 library is not available.'
             );
         }
     }

--- a/test/EasyRdf/Serialiser/GraphVizTest.php
+++ b/test/EasyRdf/Serialiser/GraphVizTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Serialiser;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -39,8 +40,8 @@ namespace EasyRdf\Serialiser;
 use EasyRdf\Graph;
 use EasyRdf\TestCase;
 
-require_once dirname(dirname(dirname(__FILE__))).
-             DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(\dirname(__DIR__)).
+             \DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class GraphVizTest extends TestCase
 {
@@ -52,7 +53,7 @@ class GraphVizTest extends TestCase
     public function setUp()
     {
         exec('which dot', $output, $retval);
-        if ($retval == 0) {
+        if (0 == $retval) {
             $this->graph = new Graph();
             $this->serialiser = new GraphViz();
 
@@ -123,7 +124,7 @@ class GraphVizTest extends TestCase
         $this->serialiser->setOnlyLabelled(false);
         $dot = $this->serialiser->serialise($this->graph, 'dot');
         $this->assertSame(
-            array(
+            [
                 'digraph {',
                 '  charset="utf-8";',
                 '',
@@ -139,8 +140,8 @@ class GraphVizTest extends TestCase
                 '  "Rhttp://www.example.com/joe#me" [URL="http://www.example.com/joe#me",'.
                 'label="http://www.example.com/joe#me",shape=ellipse,color=blue];',
                 '}',
-                ''
-            ),
+                '',
+            ],
             explode("\n", $dot)
         );
     }
@@ -152,7 +153,7 @@ class GraphVizTest extends TestCase
         $dot = $this->serialiser->serialise($this->graph, 'dot');
 
         $this->assertSame(
-            array(
+            [
                 'digraph {',
                 '  charset="utf-8";',
                 '',
@@ -168,8 +169,8 @@ class GraphVizTest extends TestCase
                 '  "Rhttp://www.example.com/joe#me" [URL="http://www.example.com/joe#me",'.
                 'label="Joe Bloggs",shape=ellipse,color=blue];',
                 '}',
-                ''
-            ),
+                '',
+            ],
             explode("\n", $dot)
         );
     }
@@ -182,7 +183,7 @@ class GraphVizTest extends TestCase
         $dot = $this->serialiser->serialise($this->graph, 'dot');
 
         $this->assertSame(
-            array(
+            [
                 'digraph {',
                 '  charset="utf-8";',
                 '',
@@ -194,8 +195,8 @@ class GraphVizTest extends TestCase
                 '  "Rhttp://www.example.com/joe#me" [URL="http://www.example.com/joe#me",'.
                 'label="Joe Bloggs",shape=ellipse,color=blue];',
                 '}',
-                ''
-            ),
+                '',
+            ],
             explode("\n", $dot)
         );
     }
@@ -210,9 +211,9 @@ class GraphVizTest extends TestCase
         );
 
         $this->assertSame('image/png', $info['mime']);
-        $this->assertLessThan(500, $info[0], 'Image width is less than 500');  # width=469
+        $this->assertLessThan(500, $info[0], 'Image width is less than 500');  // width=469
         $this->assertGreaterThan(350, $info[0], 'Image width is greater than 350');
-        $this->assertLessThan(350, $info[1], 'Image height is less than 350');  # height=299
+        $this->assertLessThan(350, $info[1], 'Image height is less than 350');  // height=299
         $this->assertGreaterThan(250, $info[1], 'Image height is greater than 250');
     }
 
@@ -226,9 +227,9 @@ class GraphVizTest extends TestCase
         );
 
         $this->assertSame('image/gif', $info['mime']);
-        $this->assertLessThan(500, $info[0], 'Image width is less than 500');  # width=469
+        $this->assertLessThan(500, $info[0], 'Image width is less than 500');  // width=469
         $this->assertGreaterThan(350, $info[0], 'Image width is greater than 350');
-        $this->assertLessThan(350, $info[1], 'Image height is less than 350');  # height=304
+        $this->assertLessThan(350, $info[1], 'Image height is less than 350');  // height=304
         $this->assertGreaterThan(250, $info[1], 'Image height is greater than 250');
     }
 

--- a/test/EasyRdf/Serialiser/JsonLdTest.php
+++ b/test/EasyRdf/Serialiser/JsonLdTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Serialiser;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -41,8 +42,8 @@ use EasyRdf\Literal;
 use EasyRdf\RdfNamespace;
 use EasyRdf\TestCase;
 
-require_once dirname(dirname(dirname(__FILE__))).
-    DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(\dirname(__DIR__)).
+    \DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class JsonLdTest extends TestCase
 {
@@ -56,7 +57,6 @@ class JsonLdTest extends TestCase
     {
         $this->graph = new Graph('http://example.com/');
         $this->serialiser = new JsonLd();
-
 
         $joe = $this->graph->resource('http://www.example.com/joe#me', 'foaf:Person');
         $joe->set('foaf:name', new Literal('Joe Bloggs', 'en'));
@@ -73,7 +73,7 @@ class JsonLdTest extends TestCase
         RdfNamespace::set('xsd', 'http://www.w3.org/2001/XMLSchema#');
         RdfNamespace::set('', 'http://foo/bar/');
 
-        $chapter=$this->graph->resource('http://example.org/library/the-republic#introduction', 'ex:Chapter');
+        $chapter = $this->graph->resource('http://example.org/library/the-republic#introduction', 'ex:Chapter');
         $chapter->set('dc:description', new Literal('An introductory chapter on The Republic.'));
         $chapter->set('dc:title', new Literal('The Introduction'));
 
@@ -135,47 +135,43 @@ class JsonLdTest extends TestCase
         $decoded = json_decode($string, true);
 
         $this->assertArrayNotHasKey('@graph', $decoded);
-        $this->assertInternalType('array', $decoded[8]["http://xmlns.com/foaf/0.1/age"][0]);
-        $this->assertSame(59, $decoded[8]["http://xmlns.com/foaf/0.1/age"][0]['@value']);
-        $this->assertArrayNotHasKey('@type', $decoded[8]["http://xmlns.com/foaf/0.1/age"][0]);
-
+        $this->assertInternalType('array', $decoded[8]['http://xmlns.com/foaf/0.1/age'][0]);
+        $this->assertSame(59, $decoded[8]['http://xmlns.com/foaf/0.1/age'][0]['@value']);
+        $this->assertArrayNotHasKey('@type', $decoded[8]['http://xmlns.com/foaf/0.1/age'][0]);
 
         // Expanded form + explicit types
-        $string = $this->serialiser->serialise($this->graph, 'jsonld', array('expand_native_types' => true));
+        $string = $this->serialiser->serialise($this->graph, 'jsonld', ['expand_native_types' => true]);
         $decoded = json_decode($string, true);
 
         $this->assertArrayNotHasKey('@graph', $decoded);
-        $this->assertInternalType('array', $decoded[8]["http://xmlns.com/foaf/0.1/age"][0]);
-        $this->assertSame('59', $decoded[8]["http://xmlns.com/foaf/0.1/age"][0]['@value']);
+        $this->assertInternalType('array', $decoded[8]['http://xmlns.com/foaf/0.1/age'][0]);
+        $this->assertSame('59', $decoded[8]['http://xmlns.com/foaf/0.1/age'][0]['@value']);
         $this->assertSame(
             'http://www.w3.org/2001/XMLSchema#integer',
-            $decoded[8]["http://xmlns.com/foaf/0.1/age"][0]['@type']
+            $decoded[8]['http://xmlns.com/foaf/0.1/age'][0]['@type']
         );
 
-
         // Compact form
-        $string = $this->serialiser->serialise($this->graph, 'jsonld', array('compact' => true));
+        $string = $this->serialiser->serialise($this->graph, 'jsonld', ['compact' => true]);
         $decoded = json_decode($string, true);
 
         $this->assertArrayHasKey('@graph', $decoded);
-        $this->assertSame(59, $decoded['@graph'][4]["http://xmlns.com/foaf/0.1/age"]);
-
+        $this->assertSame(59, $decoded['@graph'][4]['http://xmlns.com/foaf/0.1/age']);
 
         // Compact form + explicit types
         $string = $this->serialiser->serialise(
             $this->graph,
             'jsonld',
-            array('compact' => true, 'expand_native_types' => true)
+            ['compact' => true, 'expand_native_types' => true]
         );
         $decoded = json_decode($string, true);
 
         $this->assertArrayHasKey('@graph', $decoded);
-        $this->assertSame('59', $decoded['@graph'][4]["http://xmlns.com/foaf/0.1/age"]['@value']);
+        $this->assertSame('59', $decoded['@graph'][4]['http://xmlns.com/foaf/0.1/age']['@value']);
         $this->assertSame(
             'http://www.w3.org/2001/XMLSchema#integer',
-            $decoded['@graph'][4]["http://xmlns.com/foaf/0.1/age"]['@type']
+            $decoded['@graph'][4]['http://xmlns.com/foaf/0.1/age']['@type']
         );
-
 
         // Compact form + explicit types + context
         $ctx = new \stdClass();
@@ -186,33 +182,33 @@ class JsonLdTest extends TestCase
         $string = $this->serialiser->serialise(
             $this->graph,
             'jsonld',
-            array('compact' => true, 'expand_native_types' => true, 'context' => $ctx)
+            ['compact' => true, 'expand_native_types' => true, 'context' => $ctx]
         );
         $decoded = json_decode($string, true);
 
         $this->assertArrayHasKey('@graph', $decoded);
-        $this->assertSame('59', $decoded['@graph'][4]["foaf:age"]['@value']);
-        $this->assertSame('xmls:integer', $decoded['@graph'][4]["foaf:age"]['@type']);
+        $this->assertSame('59', $decoded['@graph'][4]['foaf:age']['@value']);
+        $this->assertSame('xmls:integer', $decoded['@graph'][4]['foaf:age']['@type']);
 
         // Framing
         // Maybe the context and original data could be packed in a fixture
-        $frame = (object) array(
-            '@context' => (object) array(
+        $frame = (object) [
+            '@context' => (object) [
                 'dc' => 'http://purl.org/dc/elements/1.1/',
-                'ex' => 'http://example.org/vocab#'
-            ),
+                'ex' => 'http://example.org/vocab#',
+            ],
             '@type' => 'ex:Library',
-            'ex:contains' => (object) array(
+            'ex:contains' => (object) [
                 '@type' => 'ex:Book',
-                'ex:contains' => (object) array(
-                    '@type' => 'ex:Chapter'
-                )
-            )
-        );
+                'ex:contains' => (object) [
+                    '@type' => 'ex:Chapter',
+                ],
+            ],
+        ];
         $string = $this->serialiser->serialise(
             $this->graph,
             'jsonld',
-            array('compact' => false, 'frame' => $frame)
+            ['compact' => false, 'frame' => $frame]
         );
         $decoded = json_decode($string, true);
         $this->assertArrayHasKey('@graph', $decoded);

--- a/test/EasyRdf/Serialiser/JsonTest.php
+++ b/test/EasyRdf/Serialiser/JsonTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Serialiser;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -41,8 +42,8 @@ use EasyRdf\Literal;
 use EasyRdf\RdfNamespace;
 use EasyRdf\TestCase;
 
-require_once dirname(dirname(dirname(__FILE__))).
-             DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(\dirname(__DIR__)).
+             \DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class JsonTest extends TestCase
 {

--- a/test/EasyRdf/Serialiser/NtriplesArray.php
+++ b/test/EasyRdf/Serialiser/NtriplesArray.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Serialiser;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -42,13 +43,11 @@ use EasyRdf\Graph;
 /**
  * Class to serialise an EasyRdf\Graph to an array of triples.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
 class NtriplesArray extends Ntriples
 {
-
     /**
      * Sort an array of triples into a consistent order
      *
@@ -67,39 +66,38 @@ class NtriplesArray extends Ntriples
         }
     }
 
-
     /**
      * Serialise an EasyRdf\Graph into an array of N-Triples objects
      *
-     * @param Graph  $graph  An EasyRdf\Graph object.
-     * @param string $format The name of the format to convert to.
-     * @param array  $options
+     * @param Graph  $graph  an EasyRdf\Graph object
+     * @param string $format the name of the format to convert to
      *
-     * @return string The RDF in the new desired format.
+     * @return string the RDF in the new desired format
+     *
      * @throws Exception
      */
-    public function serialise(Graph $graph, $format, array $options = array())
+    public function serialise(Graph $graph, $format, array $options = [])
     {
         parent::checkSerialiseParams($format);
 
-        $triples = array();
+        $triples = [];
         foreach ($graph->toRdfPhp() as $resource => $properties) {
             foreach ($properties as $property => $values) {
                 foreach ($values as $value) {
                     array_push(
                         $triples,
-                        array(
+                        [
                             's' => $this->serialiseResource($resource),
-                            'p' => "<" . $this->escapeString($property) . ">",
-                            'o' => $this->serialiseValue($value)
-                        )
+                            'p' => '<'.$this->escapeString($property).'>',
+                            'o' => $this->serialiseValue($value),
+                        ]
                     );
                 }
             }
         }
 
         // Sort the triples into a consistent order
-        usort($triples, array($this, 'compareTriples'));
+        usort($triples, [$this, 'compareTriples']);
 
         return $triples;
     }

--- a/test/EasyRdf/Serialiser/NtriplesTest.php
+++ b/test/EasyRdf/Serialiser/NtriplesTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Serialiser;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -42,8 +43,8 @@ use EasyRdf\RdfNamespace;
 use EasyRdf\Resource;
 use EasyRdf\TestCase;
 
-require_once dirname(dirname(dirname(__FILE__))).
-             DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(\dirname(__DIR__)).
+             \DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class NtriplesTest extends TestCase
 {
@@ -68,9 +69,9 @@ class NtriplesTest extends TestCase
     public function testSerialiseValueUriResource()
     {
         $this->assertSame(
-            "<http://example.com/>",
+            '<http://example.com/>',
             $this->serialiser->serialiseValue(
-                new Resource("http://example.com/")
+                new Resource('http://example.com/')
             )
         );
     }
@@ -78,9 +79,9 @@ class NtriplesTest extends TestCase
     public function testSerialiseValueUriArray()
     {
         $this->assertSame(
-            "<http://example.com/>",
+            '<http://example.com/>',
             $this->serialiser->serialiseValue(
-                array('type' => 'uri', 'value' => 'http://example.com/')
+                ['type' => 'uri', 'value' => 'http://example.com/']
             )
         );
     }
@@ -88,9 +89,9 @@ class NtriplesTest extends TestCase
     public function testSerialiseValueBnodeArray()
     {
         $this->assertSame(
-            "_:one",
+            '_:one',
             $this->serialiser->serialiseValue(
-                array('type' => 'bnode', 'value' => '_:one')
+                ['type' => 'bnode', 'value' => '_:one']
             )
         );
     }
@@ -98,9 +99,9 @@ class NtriplesTest extends TestCase
     public function testSerialiseValueBnodeResource()
     {
         $this->assertSame(
-            "_:two",
+            '_:two',
             $this->serialiser->serialiseValue(
-                new Resource("_:two")
+                new Resource('_:two')
             )
         );
     }
@@ -110,7 +111,7 @@ class NtriplesTest extends TestCase
         $this->assertSame(
             '"foo"',
             $this->serialiser->serialiseValue(
-                array('type' => 'literal', 'value' => 'foo')
+                ['type' => 'literal', 'value' => 'foo']
             )
         );
     }
@@ -120,7 +121,7 @@ class NtriplesTest extends TestCase
         $this->assertSame(
             '"Hello"',
             $this->serialiser->serialiseValue(
-                new Literal("Hello")
+                new Literal('Hello')
             )
         );
     }
@@ -152,7 +153,7 @@ class NtriplesTest extends TestCase
             "Unable to serialise object of type 'chipmonk' to ntriples"
         );
         $this->serialiser->serialiseValue(
-            array('type' => 'chipmonk', 'value' => 'yes?')
+            ['type' => 'chipmonk', 'value' => 'yes?']
         );
     }
 
@@ -168,14 +169,14 @@ class NtriplesTest extends TestCase
             $this->graph->resource('http://www.example.com/joe/')
         );
         $this->assertSame(
-            "<http://www.example.com/joe#me> ".
-            "<http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ".
+            '<http://www.example.com/joe#me> '.
+            '<http://www.w3.org/1999/02/22-rdf-syntax-ns#type> '.
             "<http://xmlns.com/foaf/0.1/Person> .\n".
-            "<http://www.example.com/joe#me> ".
-            "<http://xmlns.com/foaf/0.1/name> ".
+            '<http://www.example.com/joe#me> '.
+            '<http://xmlns.com/foaf/0.1/name> '.
             "\"Joe Bloggs\" .\n".
-            "<http://www.example.com/joe#me> ".
-            "<http://xmlns.com/foaf/0.1/homepage> ".
+            '<http://www.example.com/joe#me> '.
+            '<http://xmlns.com/foaf/0.1/homepage> '.
             "<http://www.example.com/joe/> .\n",
             $this->serialiser->serialise($this->graph, 'ntriples')
         );
@@ -186,8 +187,8 @@ class NtriplesTest extends TestCase
         $joe = $this->graph->resource('http://www.example.com/joe#me');
         $joe->set('foaf:nick', '"Joey"');
         $this->assertSame(
-            "<http://www.example.com/joe#me> ".
-            "<http://xmlns.com/foaf/0.1/nick> ".
+            '<http://www.example.com/joe#me> '.
+            '<http://xmlns.com/foaf/0.1/nick> '.
             '"\"Joey\"" .'."\n",
             $this->serialiser->serialise($this->graph, 'ntriples')
         );
@@ -198,8 +199,8 @@ class NtriplesTest extends TestCase
         $joe = $this->graph->resource('http://www.example.com/joe#me');
         $joe->set('foaf:nick', '\\backslash');
         $this->assertSame(
-            "<http://www.example.com/joe#me> ".
-            "<http://xmlns.com/foaf/0.1/nick> ".
+            '<http://www.example.com/joe#me> '.
+            '<http://xmlns.com/foaf/0.1/nick> '.
             '"\\\\backslash" .'."\n",
             $this->serialiser->serialise($this->graph, 'ntriples')
         );
@@ -214,11 +215,12 @@ class NtriplesTest extends TestCase
 
         $this->assertSame(
             "_:genid1 <http://xmlns.com/foaf/0.1/name> \"Project Name\" .\n".
-            "<http://www.example.com/joe#me> ".
+            '<http://www.example.com/joe#me> '.
             "<http://xmlns.com/foaf/0.1/project> _:genid1 .\n",
             $this->serialiser->serialise($this->graph, 'ntriples')
         );
     }
+
     public function testSerialiseLang()
     {
         $joe = $this->graph->resource('http://example.com/joe#me');
@@ -226,8 +228,8 @@ class NtriplesTest extends TestCase
 
         $turtle = $this->serialiser->serialise($this->graph, 'ntriples');
         $this->assertStringEquals(
-            "<http://example.com/joe#me> ".
-            "<http://xmlns.com/foaf/0.1/name> ".
+            '<http://example.com/joe#me> '.
+            '<http://xmlns.com/foaf/0.1/name> '.
             "\"Joe\"@en .\n",
             $turtle
         );
@@ -240,8 +242,8 @@ class NtriplesTest extends TestCase
 
         $ntriples = $this->serialiser->serialise($this->graph, 'ntriples');
         $this->assertStringEquals(
-            "<http://example.com/joe#me> ".
-            "<http://xmlns.com/foaf/0.1/foo> ".
+            '<http://example.com/joe#me> '.
+            '<http://xmlns.com/foaf/0.1/foo> '.
             "\"1\"^^<http://www.w3.org/2001/XMLSchema#integer> .\n",
             $ntriples
         );
@@ -264,7 +266,7 @@ class NtriplesTest extends TestCase
         $ntriples = $this->serialiser->serialise($this->graph, 'ntriples');
 
         $this->assertSame(
-            "<http://foo/bar/me> <http://xmlns.com/foaf/0.1/name> \"Joe Bloggs\" .\n" .
+            "<http://foo/bar/me> <http://xmlns.com/foaf/0.1/name> \"Joe Bloggs\" .\n".
             "<http://foo/bar/me> <http://xmlns.com/foaf/0.1/homepage> <http://example.com/joe/> .\n",
             $ntriples
         );
@@ -288,10 +290,10 @@ class NtriplesTest extends TestCase
      */
     public function testIssue219Unicode()
     {
-        $pairs = array(
+        $pairs = [
             '位' => '"\u4F4D"',
-            "Дуглас Адамс" => '"\u0414\u0443\u0433\u043B\u0430\u0441 \u0410\u0434\u0430\u043C\u0441"',
-        );
+            'Дуглас Адамс' => '"\u0414\u0443\u0433\u043B\u0430\u0441 \u0410\u0434\u0430\u043C\u0441"',
+        ];
 
         $serializer = new Ntriples();
 

--- a/test/EasyRdf/Serialiser/RapperTest.php
+++ b/test/EasyRdf/Serialiser/RapperTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Serialiser;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -39,8 +40,8 @@ namespace EasyRdf\Serialiser;
 use EasyRdf\Graph;
 use EasyRdf\TestCase;
 
-require_once dirname(dirname(dirname(__FILE__))).
-             DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(\dirname(__DIR__)).
+             \DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class RapperTest extends TestCase
 {
@@ -52,13 +53,13 @@ class RapperTest extends TestCase
     public function setUp()
     {
         exec('which rapper', $output, $retval);
-        if ($retval == 0) {
+        if (0 == $retval) {
             $this->graph = new Graph();
             $this->serialiser = new Rapper();
             parent::setUp();
         } else {
             $this->markTestSkipped(
-                "The rapper command is not available on this system."
+                'The rapper command is not available on this system.'
             );
         }
     }

--- a/test/EasyRdf/Serialiser/RdfPhpTest.php
+++ b/test/EasyRdf/Serialiser/RdfPhpTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Serialiser;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -40,8 +41,8 @@ use EasyRdf\Graph;
 use EasyRdf\Literal;
 use EasyRdf\TestCase;
 
-require_once dirname(dirname(dirname(__FILE__))).
-             DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(\dirname(__DIR__)).
+             \DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class RdfPhpTest extends TestCase
 {

--- a/test/EasyRdf/Serialiser/RdfXmlTest.php
+++ b/test/EasyRdf/Serialiser/RdfXmlTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Serialiser;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -38,12 +39,12 @@ namespace EasyRdf\Serialiser;
 
 use EasyRdf\Graph;
 use EasyRdf\Literal;
-use EasyRdf\Resource;
 use EasyRdf\RdfNamespace;
+use EasyRdf\Resource;
 use EasyRdf\TestCase;
 
-require_once dirname(dirname(dirname(__FILE__))).
-             DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(\dirname(__DIR__)).
+             \DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class RdfXmlTest extends TestCase
 {
@@ -200,7 +201,7 @@ class RdfXmlTest extends TestCase
     {
         $joe = $this->graph->resource(
             'http://www.example.com/joe#me',
-            array('foaf:Person', 'foaf:Mammal')
+            ['foaf:Person', 'foaf:Mammal']
         );
         $joe->set('foaf:name', 'Joe Bloggs');
 
@@ -285,10 +286,9 @@ class RdfXmlTest extends TestCase
 
         $xml = $this->serialiser->serialise($this->graph, 'rdfxml');
         $this->assertContains(
-            "<foaf:age rdf:datatype=\"http://www.w3.org/2001/XMLSchema#int\">59</foaf:age>",
+            '<foaf:age rdf:datatype="http://www.w3.org/2001/XMLSchema#int">59</foaf:age>',
             $xml
         );
-
     }
 
     public function testSerialiseRdfXmlWithUnknownProperty()
@@ -300,8 +300,8 @@ class RdfXmlTest extends TestCase
         );
 
         $xml = $this->serialiser->serialise($this->graph, 'rdfxml');
-        $this->assertContains("<ns0:foo>bar</ns0:foo>", $xml);
-        $this->assertContains("xmlns:ns0=\"http://www.example.com/ns/\"", $xml);
+        $this->assertContains('<ns0:foo>bar</ns0:foo>', $xml);
+        $this->assertContains('xmlns:ns0="http://www.example.com/ns/"', $xml);
     }
 
     public function testSerialiseRdfXmlWithUnshortenableProperty()
@@ -324,12 +324,12 @@ class RdfXmlTest extends TestCase
         $this->graph->add(
             'http://www.example.com/joe#me',
             'foaf:bio',
-            Literal::create("<b>html</b>", null, 'rdf:XMLLiteral')
+            Literal::create('<b>html</b>', null, 'rdf:XMLLiteral')
         );
 
         $xml = $this->serialiser->serialise($this->graph, 'rdfxml');
         $this->assertContains(
-            "<foaf:bio rdf:parseType=\"Literal\"><b>html</b></foaf:bio>",
+            '<foaf:bio rdf:parseType="Literal"><b>html</b></foaf:bio>',
             $xml
         );
     }
@@ -359,7 +359,7 @@ class RdfXmlTest extends TestCase
             "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n".
             "<rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\"\n".
             "         xmlns:foaf=\"http://xmlns.com/foaf/0.1/\"\n".
-            "         xmlns:dc=\"http://purl.org/dc/terms/\">\n\n" .
+            "         xmlns:dc=\"http://purl.org/dc/terms/\">\n\n".
             "  <foaf:Person rdf:about=\"http://www.example.com/joe#me\">\n".
             "    <dc:creator>Max Bloggs</dc:creator>\n".
             "  </foaf:Person>\n\n".
@@ -396,8 +396,8 @@ class RdfXmlTest extends TestCase
 
     public function testSerialiseContainer()
     {
-        $joe =  $this->graph->resource('http://example.com/joe', 'foaf:Person');
-        $pets =  $this->graph->newBnode('rdf:Seq');
+        $joe = $this->graph->resource('http://example.com/joe', 'foaf:Person');
+        $pets = $this->graph->newBnode('rdf:Seq');
         $pets->append('Rat');
         $pets->append('Cat');
         $pets->append('Goat');
@@ -420,12 +420,12 @@ class RdfXmlTest extends TestCase
             $this->serialiser->serialise($this->graph, 'rdfxml')
         );
     }
-    
+
     public function testSerialiseTriplesWithoutType()
     {
         $this->graph->add('http://example.com/joe', 'foaf:knows', 'http://example.com/bob');
         $this->graph->addLiteral('http://example.com/joe', 'rdf:label', 'le Joe', 'fr-FR');
-        
+
         $this->assertSame(
             "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n".
             "<rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\"\n".
@@ -438,13 +438,13 @@ class RdfXmlTest extends TestCase
             $this->serialiser->serialise($this->graph, 'rdfxml')
         );
     }
-    
+
     public function testSerialiseTriplesWithType()
     {
         $this->graph->add('http://example.com/joe', 'rdf:type', 'foaf:Person');
         $this->graph->add('http://example.com/joe', 'foaf:knows', 'http://example.com/bob');
         $this->graph->addLiteral('http://example.com/joe', 'rdf:label', 'le Joe', 'fr-FR');
-        
+
         $this->assertSame(
             "<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n".
             "<rdf:RDF xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\"\n".
@@ -505,7 +505,7 @@ class RdfXmlTest extends TestCase
         $g2 = new Graph('http://example.com/', $xml, 'rdfxml');
         $types = $g2->resource('http://example.com/resource')->typesAsResources();
 
-        $expected = array('http://example.com/TypeA', 'http://xmlns.com/foaf/0.1/Person');
+        $expected = ['http://example.com/TypeA', 'http://xmlns.com/foaf/0.1/Person'];
 
         $this->assertCount(2, $types);
         $this->assertContains($types[0]->getUri(), $expected);

--- a/test/EasyRdf/Serialiser/TurtleTest.php
+++ b/test/EasyRdf/Serialiser/TurtleTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Serialiser;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -41,8 +42,8 @@ use EasyRdf\Literal;
 use EasyRdf\RdfNamespace;
 use EasyRdf\TestCase;
 
-require_once dirname(dirname(dirname(__FILE__))).
-             DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(\dirname(__DIR__)).
+             \DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class TurtleTest extends TestCase
 {
@@ -305,7 +306,7 @@ class TurtleTest extends TestCase
     public function testSerialiseAnonymousSubject()
     {
         $this->graph->resource('http://example.com/joe#me');
-        $anon =  $this->graph->newBnode();
+        $anon = $this->graph->newBnode();
         $anon->addLiteral('foaf:name', 'Anon');
 
         $turtle = $this->serialiser->serialise($this->graph, 'turtle');
@@ -321,7 +322,7 @@ class TurtleTest extends TestCase
     {
         $joe = $this->graph->resource('http://example.com/joe#me');
         $alice = $this->graph->resource('http://example.com/alice#me');
-        $project =  $this->graph->newBnode();
+        $project = $this->graph->newBnode();
         $project->add('foaf:name', 'Amazing Project');
         $joe->add('foaf:currentProject', $project);
         $alice->add('foaf:currentProject', $project);
@@ -339,7 +340,7 @@ class TurtleTest extends TestCase
     public function testSerialiseNestedBnode1()
     {
         $joe = $this->graph->resource('http://example.com/joe#me');
-        $amy =  $this->graph->newBnode();
+        $amy = $this->graph->newBnode();
         $amy->addLiteral('foaf:name', 'Amy');
         $joe->add('foaf:knows', $amy);
 
@@ -400,8 +401,8 @@ class TurtleTest extends TestCase
 
     public function testSerialiseNestedBnode4()
     {
-        $joe =  $this->graph->newBnode();
-        $alice =  $this->graph->newBnode();
+        $joe = $this->graph->newBnode();
+        $alice = $this->graph->newBnode();
         $joe->add('foaf:name', 'Joe');
         $alice->add('foaf:name', 'Alice');
         $joe->add('foaf:knows', $alice);
@@ -422,8 +423,8 @@ class TurtleTest extends TestCase
 
     public function testSerialiseCollection()
     {
-        $joe =  $this->graph->resource('http://example.com/joe');
-        $pets =  $this->graph->newBnode('rdf:List');
+        $joe = $this->graph->resource('http://example.com/joe');
+        $pets = $this->graph->newBnode('rdf:List');
         $pets->append('Rat');
         $pets->append('Cat');
         $pets->append('Goat');
@@ -443,8 +444,8 @@ class TurtleTest extends TestCase
 
     public function testSerialiseCollectionSingle()
     {
-        $joe =  $this->graph->resource('http://example.com/joe');
-        $pets =  $this->graph->newBnode('rdf:List');
+        $joe = $this->graph->resource('http://example.com/joe');
+        $pets = $this->graph->newBnode('rdf:List');
         $pets->append('Rat');
         $joe->add('foaf:pets', $pets);
 
@@ -458,8 +459,8 @@ class TurtleTest extends TestCase
 
     public function testSerialiseCollectionEmpty()
     {
-        $joe =  $this->graph->resource('http://example.com/joe');
-        $pets =  $this->graph->newBnode('rdf:List');
+        $joe = $this->graph->resource('http://example.com/joe');
+        $pets = $this->graph->newBnode('rdf:List');
         $joe->add('foaf:pets', $pets);
 
         $turtle = $this->serialiser->serialise($this->graph, 'turtle');
@@ -647,7 +648,7 @@ class TurtleTest extends TestCase
 
     public function testSerialiseShortenableResource()
     {
-        RdfNamespace::set("example", 'http://example.com/');
+        RdfNamespace::set('example', 'http://example.com/');
         $joe = $this->graph->resource('http://example.com/joe#me');
         $joe->add('rdf:type', 'foaf:Person');
 
@@ -682,7 +683,7 @@ class TurtleTest extends TestCase
 
         $turtle = $this->serialiser->serialise($this->graph, 'turtle');
         $this->assertContains(
-            "@prefix ns0: <http://example.com/ns/> .",
+            '@prefix ns0: <http://example.com/ns/> .',
             $turtle
         );
         $this->assertSame(

--- a/test/EasyRdf/SerialiserTest.php
+++ b/test/EasyRdf/SerialiserTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EasyRdf;
 
 /**
@@ -31,16 +32,14 @@ namespace EasyRdf;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
-
-require_once dirname(__DIR__).DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(__DIR__).\DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class MockSerialiser extends Serialiser
 {
-    public function serialise(Graph $graph, $format, array $options = array())
+    public function serialise(Graph $graph, $format, array $options = [])
     {
         parent::checkSerialiseParams($format);
         // Serialising goes here
@@ -52,7 +51,7 @@ class SerialiserTest extends TestCase
 {
     /** @var Graph */
     private $graph;
-    /** @var Resource */
+    /** @var resource */
     private $resource;
     /** @var Serialiser */
     private $serialiser;

--- a/test/EasyRdf/Sparql/ClientTest.php
+++ b/test/EasyRdf/Sparql/ClientTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Sparql;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -42,15 +43,14 @@ use EasyRdf\Literal;
 use EasyRdf\Resource;
 use EasyRdf\TestCase;
 
-require_once realpath(__DIR__ . '/../../') . '/TestHelper.php';
-
+require_once realpath(__DIR__.'/../../').'/TestHelper.php';
 
 class ClientTest extends TestCase
 {
-    /** @var  MockClient */
+    /** @var MockClient */
     private $client;
 
-    /** @var  Client */
+    /** @var Client */
     private $sparql;
 
     public function setUp()
@@ -61,7 +61,7 @@ class ClientTest extends TestCase
         $this->sparql = new Client('http://localhost:8080/sparql');
     }
 
-    # FIXME: this is deprecated
+    // FIXME: this is deprecated
     public function testGetUri()
     {
         $this->assertSame(
@@ -77,7 +77,7 @@ class ClientTest extends TestCase
             $this->sparql->getQueryUri()
         );
     }
-    
+
     public function testGetUpdateUri()
     {
         $this->assertSame(
@@ -108,11 +108,11 @@ class ClientTest extends TestCase
             'GET',
             '/sparql?query=SELECT+%2A+WHERE+%7B%3Fs+%3Fp+%3Fo%7D',
             readFixture('sparql_select_all.xml'),
-            array(
-                'headers' => array('Content-Type' => 'application/sparql-results+xml')
-            )
+            [
+                'headers' => ['Content-Type' => 'application/sparql-results+xml'],
+            ]
         );
-        $result = $this->sparql->query("SELECT * WHERE {?s ?p ?o}");
+        $result = $this->sparql->query('SELECT * WHERE {?s ?p ?o}');
         $this->assertCount(14, $result);
         $this->assertEquals(
             new Resource('_:genid1'),
@@ -134,14 +134,14 @@ class ClientTest extends TestCase
             'GET',
             '/sparql?query=SELECT+%2A+WHERE+%7B%3Fs+%3Fp+%3Fo%7D',
             readFixture('sparql_select_all.json'),
-            array(
-                'headers' => array('Content-Type' => 'application/sparql-results+json; charset=utf-8')
-            )
+            [
+                'headers' => ['Content-Type' => 'application/sparql-results+json; charset=utf-8'],
+            ]
         );
-        $result = $this->sparql->query("SELECT * WHERE {?s ?p ?o}");
+        $result = $this->sparql->query('SELECT * WHERE {?s ?p ?o}');
         $this->assertCount(14, $result);
         $this->assertSame(3, $result->numFields());
-        $this->assertSame(array('s','p','o'), $result->getFields());
+        $this->assertSame(['s', 'p', 'o'], $result->getFields());
         $this->assertEquals(
             new Literal("Joe's Current Project"),
             $result[0]->o
@@ -154,21 +154,22 @@ class ClientTest extends TestCase
             'GET',
             '/sparql?query=SELECT+%2A+WHERE+%7B%3Fs+%3Fp+%3Fo%7D',
             readFixture('sparql_select_all.json'),
-            array(
-                'headers' => array('Content-Type' => 'unsupported/format')
-            )
+            [
+                'headers' => ['Content-Type' => 'unsupported/format'],
+            ]
         );
         $this->setExpectedException(
             'EasyRdf\Exception',
             'Format is not recognised: unsupported/format'
         );
-        $this->sparql->query("SELECT * WHERE {?s ?p ?o}");
+        $this->sparql->query('SELECT * WHERE {?s ?p ?o}');
     }
 
     public function checkHugeQuerySelect($client)
     {
         $this->assertRegExp('/^query=/', $client->getRawData());
-        $this->assertSame("application/x-www-form-urlencoded", $client->getHeader('Content-Type'));
+        $this->assertSame('application/x-www-form-urlencoded', $client->getHeader('Content-Type'));
+
         return true;
     }
 
@@ -178,10 +179,10 @@ class ClientTest extends TestCase
             'POST',
             '/sparql',
             readFixture('sparql_select_all.json'),
-            array(
-                'headers' => array('Content-Type' => 'application/sparql-results+json'),
-                'callback' => array($this, 'checkHugeQuerySelect')
-            )
+            [
+                'headers' => ['Content-Type' => 'application/sparql-results+json'],
+                'callback' => [$this, 'checkHugeQuerySelect'],
+            ]
         );
 
         // Add extra 2k+ of comment to start of query
@@ -198,11 +199,11 @@ class ClientTest extends TestCase
             '1999%2F02%2F22-rdf-syntax-ns%23%3E%0ASELECT+%3Ft+WHERE+'.
             '%7B%3Fs+rdf%3Atype+%3Ft%7D',
             readFixture('sparql_select_all_types.xml'),
-            array(
-                'headers' => array('Content-Type' => 'application/sparql-results+xml')
-            )
+            [
+                'headers' => ['Content-Type' => 'application/sparql-results+xml'],
+            ]
         );
-        $result = $this->sparql->query("SELECT ?t WHERE {?s rdf:type ?t}");
+        $result = $this->sparql->query('SELECT ?t WHERE {?s rdf:type ?t}');
         $this->assertCount(3, $result);
         $this->assertEquals(
             new Resource('http://xmlns.com/foaf/0.1/Project'),
@@ -224,12 +225,12 @@ class ClientTest extends TestCase
             'GET',
             '/sparql?query=ASK+WHERE+%7B%3Fs+%3Fp+%3Fo%7D',
             readFixture('sparql_ask_true.xml'),
-            array(
-                'headers' => array('Content-Type' => 'application/sparql-results+xml')
-            )
+            [
+                'headers' => ['Content-Type' => 'application/sparql-results+xml'],
+            ]
         );
-        $result = $this->sparql->query("ASK WHERE {?s ?p ?o}");
-        $this->assertSame(true, $result->getBoolean());
+        $result = $this->sparql->query('ASK WHERE {?s ?p ?o}');
+        $this->assertTrue($result->getBoolean());
     }
 
     public function testQueryAskFalse()
@@ -238,12 +239,12 @@ class ClientTest extends TestCase
             'GET',
             '/sparql?query=ASK+WHERE+%7B%3Fs+%3Fp+%3Cfalse%3E%7D',
             readFixture('sparql_ask_false.xml'),
-            array(
-                'headers' => array('Content-Type' => 'application/sparql-results+xml')
-            )
+            [
+                'headers' => ['Content-Type' => 'application/sparql-results+xml'],
+            ]
         );
-        $result = $this->sparql->query("ASK WHERE {?s ?p <false>}");
-        $this->assertSame(false, $result->getBoolean());
+        $result = $this->sparql->query('ASK WHERE {?s ?p <false>}');
+        $this->assertFalse($result->getBoolean());
     }
 
     public function testQueryConstructJson()
@@ -252,11 +253,11 @@ class ClientTest extends TestCase
             'GET',
             '/sparql?query=CONSTRUCT+%7B%3Fs+%3Fp+%3Fo%7D+WHERE+%7B%3Fs+%3Fp+%3Fo%7D',
             readFixture('foaf.json'),
-            array(
-                'headers' => array('Content-Type' => 'application/json')
-            )
+            [
+                'headers' => ['Content-Type' => 'application/json'],
+            ]
         );
-        $graph = $this->sparql->query("CONSTRUCT {?s ?p ?o} WHERE {?s ?p ?o}");
+        $graph = $this->sparql->query('CONSTRUCT {?s ?p ?o} WHERE {?s ?p ?o}');
         $this->assertClass('EasyRdf\Graph', $graph);
         $name = $graph->get('http://www.example.com/joe#me', 'foaf:name');
         $this->assertStringEquals('Joe Bloggs', $name);
@@ -268,11 +269,11 @@ class ClientTest extends TestCase
             'GET',
             '/sparql?query=CONSTRUCT+%7B%3Fs+%3Fp+%3Fo%7D+WHERE+%7B%3Fs+%3Fp+%3Fo%7D',
             readFixture('foaf.json'),
-            array(
-                'headers' => array('Content-Type' => 'application/json; charset=utf-8')
-            )
+            [
+                'headers' => ['Content-Type' => 'application/json; charset=utf-8'],
+            ]
         );
-        $graph = $this->sparql->query("CONSTRUCT {?s ?p ?o} WHERE {?s ?p ?o}");
+        $graph = $this->sparql->query('CONSTRUCT {?s ?p ?o} WHERE {?s ?p ?o}');
         $this->assertClass('EasyRdf\Graph', $graph);
         $name = $graph->get('http://www.example.com/joe#me', 'foaf:name');
         $this->assertStringEquals('Joe Bloggs', $name);
@@ -286,14 +287,14 @@ class ClientTest extends TestCase
             'GET',
             '/sparql?query=FOOBAR',
             $body,
-            array(
+            [
                 'status' => 500,
-                'headers' => array('Content-Type' => 'text/plain')
-            )
+                'headers' => ['Content-Type' => 'text/plain'],
+            ]
         );
 
         try {
-            $this->sparql->query("FOOBAR");
+            $this->sparql->query('FOOBAR');
             $this->fail('Invalid query should have resulted in an exception');
         } catch (Http\Exception $e) {
             $this->assertEquals('HTTP request for SPARQL query failed', $e->getMessage());
@@ -307,9 +308,9 @@ class ClientTest extends TestCase
             'GET',
             '/sparql?query=SELECT+%28COUNT%28%2A%29+AS+%3Fcount%29+%7B%3Fs+%3Fp+%3Fo%7D',
             readFixture('sparql_select_count.json'),
-            array(
-                'headers' => array('Content-Type' => 'application/sparql-results+json; charset=utf-8')
-            )
+            [
+                'headers' => ['Content-Type' => 'application/sparql-results+json; charset=utf-8'],
+            ]
         );
         $count = $this->sparql->countTriples();
         $this->assertSame(143, $count);
@@ -322,9 +323,9 @@ class ClientTest extends TestCase
             '/sparql?query=PREFIX+foaf%3A+%3Chttp%3A%2F%2Fxmlns.com%2Ffoaf%2F0.1%2F%3E%0A'.
             'SELECT+%28COUNT%28%2A%29+AS+%3Fcount%29+%7B%3Fs+a+foaf%3APerson%7D',
             readFixture('sparql_select_count_zero.json'),
-            array(
-                'headers' => array('Content-Type' => 'application/sparql-results+json; charset=utf-8')
-            )
+            [
+                'headers' => ['Content-Type' => 'application/sparql-results+json; charset=utf-8'],
+            ]
         );
         $count = $this->sparql->countTriples('?s a foaf:Person');
         $this->assertSame(0, $count);
@@ -336,9 +337,9 @@ class ClientTest extends TestCase
             'GET',
             '/sparql?query=SELECT+DISTINCT+%3Fg+WHERE+%7BGRAPH+%3Fg+%7B%3Fs+%3Fp+%3Fo%7D%7D',
             readFixture('sparql_select_named_graphs.json'),
-            array(
-                'headers' => array('Content-Type' => 'application/sparql-results+json; charset=utf-8')
-            )
+            [
+                'headers' => ['Content-Type' => 'application/sparql-results+json; charset=utf-8'],
+            ]
         );
         $list = $this->sparql->listNamedGraphs();
         $this->assertCount(3, $list);
@@ -353,9 +354,9 @@ class ClientTest extends TestCase
             'GET',
             '/sparql?query=SELECT+DISTINCT+%3Fg+WHERE+%7BGRAPH+%3Fg+%7B%3Fs+%3Fp+%3Fo%7D%7D+LIMIT+10',
             readFixture('sparql_select_named_graphs.json'),
-            array(
-                'headers' => array('Content-Type' => 'application/sparql-results+json; charset=utf-8')
-            )
+            [
+                'headers' => ['Content-Type' => 'application/sparql-results+json; charset=utf-8'],
+            ]
         );
         $list = $this->sparql->listNamedGraphs(10);
         $this->assertCount(3, $list);
@@ -367,20 +368,21 @@ class ClientTest extends TestCase
     public function checkUpdate(Http\Client $client)
     {
         $this->assertSame('INSERT DATA { <a> <p> <b> }', $client->getRawData());
-        $this->assertSame("application/sparql-update", $client->getHeader('Content-Type'));
+        $this->assertSame('application/sparql-update', $client->getHeader('Content-Type'));
+
         return true;
     }
-    
+
     public function testUpdate()
     {
         $this->client->addMock(
             'POST',
             '/sparql',
             '',
-            array(
+            [
                 'status' => 204,
-                'callback' => array($this, 'checkUpdate')
-            )
+                'callback' => [$this, 'checkUpdate'],
+            ]
         );
 
         $result = $this->sparql->update('INSERT DATA { <a> <p> <b> }');
@@ -395,11 +397,11 @@ class ClientTest extends TestCase
             'GET',
             '/sparql?a=b&query=SELECT+%2A+WHERE+%7B%3Fs+%3Fp+%3Fo%7D',
             readFixture('sparql_select_all.xml'),
-            array(
-                'headers' => array('Content-Type' => 'application/sparql-results+xml')
-            )
+            [
+                'headers' => ['Content-Type' => 'application/sparql-results+xml'],
+            ]
         );
-        $result = $this->sparql->query("SELECT * WHERE {?s ?p ?o}");
+        $result = $this->sparql->query('SELECT * WHERE {?s ?p ?o}');
         $this->assertCount(14, $result);
         $this->assertEquals(
             new Resource('_:genid1'),
@@ -418,6 +420,7 @@ class ClientTest extends TestCase
     /**
      * Make sure, that different queries have different Accept headers
      * This is important for compatibility with real-world triplestores
+     *
      * @see https://github.com/njh/easyrdf/issues/226
      * @see https://github.com/njh/easyrdf/issues/231
      */
@@ -464,11 +467,11 @@ class ClientTest extends TestCase
 
     private static function parseAcceptHeader($accept_str)
     {
-        $types = array();
+        $types = [];
 
         $pieces = explode(',', $accept_str);
         foreach ($pieces as $piece) {
-            list($type,) = explode(';', $piece, 2);
+            list($type) = explode(';', $piece, 2);
             $types[] = $type;
         }
 

--- a/test/EasyRdf/Sparql/ResultTest.php
+++ b/test/EasyRdf/Sparql/ResultTest.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf\Sparql;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -40,8 +41,7 @@ use EasyRdf\Literal;
 use EasyRdf\Resource;
 use EasyRdf\TestCase;
 
-require_once realpath(dirname(__FILE__) . '/../../') . '/TestHelper.php';
-
+require_once realpath(__DIR__.'/../../').'/TestHelper.php';
 
 class ResultTest extends TestCase
 {
@@ -53,11 +53,11 @@ class ResultTest extends TestCase
         );
 
         $this->assertSame(3, $result->numFields());
-        $this->assertSame(array('s','p','o'), $result->getFields());
+        $this->assertSame(['s', 'p', 'o'], $result->getFields());
 
         $this->assertCount(14, $result);
         $this->assertSame(14, $result->numRows());
-        $this->assertSame(14, count($result));
+        $this->assertSame(14, \count($result));
         $this->assertEquals(
             new Resource('_:genid1'),
             $result[0]->s
@@ -80,11 +80,11 @@ class ResultTest extends TestCase
         );
 
         $this->assertSame(3, $result->numFields());
-        $this->assertSame(array('s','p','o'), $result->getFields());
+        $this->assertSame(['s', 'p', 'o'], $result->getFields());
 
         $this->assertCount(14, $result);
         $this->assertSame(14, $result->numRows());
-        $this->assertSame(14, count($result));
+        $this->assertSame(14, \count($result));
         $this->assertEquals(
             new Resource('_:genid1'),
             $result[0]->s
@@ -107,11 +107,11 @@ class ResultTest extends TestCase
         );
 
         $this->assertSame(3, $result->numFields());
-        $this->assertSame(array('s','p','o'), $result->getFields());
+        $this->assertSame(['s', 'p', 'o'], $result->getFields());
 
         $this->assertCount(14, $result);
         $this->assertSame(14, $result->numRows());
-        $this->assertSame(14, count($result));
+        $this->assertSame(14, \count($result));
         $this->assertEquals(
             new Resource('_:genid1'),
             $result[0]->s
@@ -134,7 +134,7 @@ class ResultTest extends TestCase
         );
 
         $this->assertSame(3, $result->numFields());
-        $this->assertSame(array('s','p','o'), $result->getFields());
+        $this->assertSame(['s', 'p', 'o'], $result->getFields());
         $this->assertCount(0, $result);
     }
 
@@ -146,7 +146,7 @@ class ResultTest extends TestCase
         );
 
         $this->assertSame(3, $result->numFields());
-        $this->assertSame(array('s','p','o'), $result->getFields());
+        $this->assertSame(['s', 'p', 'o'], $result->getFields());
         $this->assertCount(0, $result);
     }
 
@@ -157,23 +157,23 @@ class ResultTest extends TestCase
             'application/sparql-results+xml'
         );
 
-        # 1st: Example using xml:lang="en"
+        // 1st: Example using xml:lang="en"
         $first = $result[0];
         $this->assertSame('London', $first->label->getValue());
         $this->assertSame('en', $first->label->getLang());
-        $this->assertSame(null, $first->label->getDatatype());
+        $this->assertNull($first->label->getDatatype());
 
-        # 2nd: Example using xml:lang="es"
+        // 2nd: Example using xml:lang="es"
         $second = $result[1];
         $this->assertSame('Londres', $second->label->getValue());
         $this->assertSame('es', $second->label->getLang());
-        $this->assertSame(null, $second->label->getDatatype());
+        $this->assertNull($second->label->getDatatype());
 
-        # 3rd: no lang
+        // 3rd: no lang
         $third = $result[2];
         $this->assertSame('London', $third->label->getValue());
-        $this->assertSame(null, $third->label->getLang());
-        $this->assertSame(null, $third->label->getDatatype());
+        $this->assertNull($third->label->getLang());
+        $this->assertNull($third->label->getDatatype());
     }
 
     public function testSelectLangLiteralJson()
@@ -183,23 +183,23 @@ class ResultTest extends TestCase
             'application/sparql-results+json'
         );
 
-        # 1st: Example using xml:lang="en"
+        // 1st: Example using xml:lang="en"
         $first = $result[0];
         $this->assertSame('London', $first->label->getValue());
         $this->assertSame('en', $first->label->getLang());
-        $this->assertSame(null, $first->label->getDatatype());
+        $this->assertNull($first->label->getDatatype());
 
-        # 2nd: Example using lang="es"
+        // 2nd: Example using lang="es"
         $second = $result[1];
         $this->assertSame('Londres', $second->label->getValue());
         $this->assertSame('es', $second->label->getLang());
-        $this->assertSame(null, $second->label->getDatatype());
+        $this->assertNull($second->label->getDatatype());
 
-        # 3rd: no lang
+        // 3rd: no lang
         $third = $result[2];
         $this->assertSame('London', $third->label->getValue());
-        $this->assertSame(null, $third->label->getLang());
-        $this->assertSame(null, $third->label->getDatatype());
+        $this->assertNull($third->label->getLang());
+        $this->assertNull($third->label->getDatatype());
     }
 
     public function testSelectTypedLiteralJson()
@@ -238,12 +238,12 @@ class ResultTest extends TestCase
         $this->assertSame('boolean', $result->getType());
         $this->assertFalse($result->isFalse());
         $this->assertTrue($result->isTrue());
-        $this->assertSame(true, $result->getBoolean());
+        $this->assertTrue($result->getBoolean());
         $this->assertStringEquals('true', $result);
 
         $this->assertSame(0, $result->numFields());
         $this->assertSame(0, $result->numRows());
-        $this->assertSame(0, count($result));
+        $this->assertSame(0, \count($result));
     }
 
     public function testAskFalseJson()
@@ -256,12 +256,12 @@ class ResultTest extends TestCase
         $this->assertSame('boolean', $result->getType());
         $this->assertTrue($result->isFalse());
         $this->assertFalse($result->isTrue());
-        $this->assertSame(false, $result->getBoolean());
+        $this->assertFalse($result->getBoolean());
         $this->assertStringEquals('false', $result);
 
         $this->assertSame(0, $result->numFields());
         $this->assertSame(0, $result->numRows());
-        $this->assertSame(0, count($result));
+        $this->assertSame(0, \count($result));
     }
 
     public function testAskTrueXml()
@@ -273,12 +273,12 @@ class ResultTest extends TestCase
         $this->assertSame('boolean', $result->getType());
         $this->assertFalse($result->isFalse());
         $this->assertTrue($result->isTrue());
-        $this->assertSame(true, $result->getBoolean());
+        $this->assertTrue($result->getBoolean());
         $this->assertStringEquals('true', $result);
 
         $this->assertSame(0, $result->numFields());
         $this->assertSame(0, $result->numRows());
-        $this->assertSame(0, count($result));
+        $this->assertSame(0, \count($result));
     }
 
     public function testAskFalseXml()
@@ -290,12 +290,12 @@ class ResultTest extends TestCase
         $this->assertSame('boolean', $result->getType());
         $this->assertTrue($result->isFalse());
         $this->assertFalse($result->isTrue());
-        $this->assertSame(false, $result->getBoolean());
+        $this->assertFalse($result->getBoolean());
         $this->assertStringEquals('false', $result);
 
         $this->assertSame(0, $result->numFields());
         $this->assertSame(0, $result->numRows());
-        $this->assertSame(0, count($result));
+        $this->assertSame(0, \count($result));
     }
 
     public function testInvalidXml()
@@ -355,14 +355,14 @@ class ResultTest extends TestCase
 
         $html = $result->dump('html');
         $this->assertContains("<table class='sparql-results'", $html);
-        $this->assertContains(">?s</th>", $html);
-        $this->assertContains(">?p</th>", $html);
-        $this->assertContains(">?o</th></tr>", $html);
+        $this->assertContains('>?s</th>', $html);
+        $this->assertContains('>?p</th>', $html);
+        $this->assertContains('>?o</th></tr>', $html);
 
-        $this->assertContains(">http://www.example.com/joe#me</a></td>", $html);
-        $this->assertContains(">foaf:name</a></td>", $html);
-        $this->assertContains(">&quot;Joe Bloggs&quot;@en</span></td>", $html);
-        $this->assertContains("</table>", $html);
+        $this->assertContains('>http://www.example.com/joe#me</a></td>', $html);
+        $this->assertContains('>foaf:name</a></td>', $html);
+        $this->assertContains('>&quot;Joe Bloggs&quot;@en</span></td>', $html);
+        $this->assertContains('</table>', $html);
     }
 
     public function testDumpSelectAllText()
@@ -392,9 +392,9 @@ class ResultTest extends TestCase
         );
 
         $html = $result->dump('html');
-        $this->assertContains(">?person</th>", $html);
-        $this->assertContains(">?name</th>", $html);
-        $this->assertContains(">?foo</th>", $html);
+        $this->assertContains('>?person</th>', $html);
+        $this->assertContains('>?name</th>', $html);
+        $this->assertContains('>?foo</th>', $html);
 
         $this->assertContains('>http://dbpedia.org/resource/Tim_Berners-Lee</a>', $html);
         $this->assertContains('>&quot;Tim Berners-Lee&quot;@en</span>', $html);
@@ -409,7 +409,7 @@ class ResultTest extends TestCase
         );
 
         $html = $result->dump('html');
-        $this->assertContains(">false</span>", $html);
+        $this->assertContains('>false</span>', $html);
     }
 
     public function testDumpAskFalseText()
@@ -420,7 +420,7 @@ class ResultTest extends TestCase
         );
 
         $text = $result->dump('text');
-        $this->assertSame("Result: false", $text);
+        $this->assertSame('Result: false', $text);
     }
 
     public function testDumpUnknownType()
@@ -454,7 +454,7 @@ class ResultTest extends TestCase
             'application/sparql-results+xml'
         );
 
-        $this->assertSame("true", strval($result));
+        $this->assertSame('true', (string) $result);
     }
 
     public function testToStringBooleanFalse()
@@ -464,7 +464,7 @@ class ResultTest extends TestCase
             'application/sparql-results+xml'
         );
 
-        $this->assertSame("false", strval($result));
+        $this->assertSame('false', (string) $result);
     }
 
     public function testToStringSelectAll()
@@ -474,7 +474,7 @@ class ResultTest extends TestCase
             'application/sparql-results+xml'
         );
 
-        $string = strval($result);
+        $string = (string) $result;
         $this->assertContains('+-------------------------------------+', $string);
         $this->assertContains('| http://www.example.com/joe#me       |', $string);
     }

--- a/test/EasyRdf/TestCase.php
+++ b/test/EasyRdf/TestCase.php
@@ -1,7 +1,8 @@
 <?php
+
 namespace EasyRdf;
 
-/**
+/*
  * EasyRdf
  *
  * LICENSE
@@ -43,16 +44,15 @@ if (!class_exists('\PHPUnit\Framework\Error\Error', true)) {
 
 class TestCase extends \PHPUnit\Framework\TestCase
 {
-
     public static function assertStringEquals($str1, $str2, $message = null)
     {
-        self::assertSame(strval($str1), strval($str2), (string) $message);
+        self::assertSame((string) $str1, (string) $str2, (string) $message);
     }
 
     // Note: this differs from assertInstanceOf because it disallows subclasses
     public static function assertClass($class, $object)
     {
-        self::assertSame($class, get_class($object));
+        self::assertSame($class, \get_class($object));
     }
 
     // Forward compatibility layer for PHPUnit 6/7

--- a/test/EasyRdf/TypeMapperTest.php
+++ b/test/EasyRdf/TypeMapperTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EasyRdf;
 
 /**
@@ -31,12 +32,10 @@ namespace EasyRdf;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
-
-require_once dirname(__DIR__).DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(__DIR__).\DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class MyTypeClass extends Resource
 {
@@ -45,7 +44,6 @@ class MyTypeClass extends Resource
         return true;
     }
 }
-
 
 class TypeMapperTest extends TestCase
 {
@@ -59,7 +57,6 @@ class TypeMapperTest extends TestCase
         TypeMapper::delete('rdf:mytype');
         TypeMapper::delete('foaf:Person');
     }
-
 
     public function testGet()
     {
@@ -103,12 +100,12 @@ class TypeMapperTest extends TestCase
             'InvalidArgumentException',
             '$type should be a string and cannot be null or empty'
         );
-        TypeMapper::get(array());
+        TypeMapper::get([]);
     }
 
     public function testGetUnknown()
     {
-        $this->assertSame(null, TypeMapper::get('unknown:type'));
+        $this->assertNull(TypeMapper::get('unknown:type'));
     }
 
     public function testSetUri()
@@ -148,7 +145,7 @@ class TypeMapperTest extends TestCase
             'InvalidArgumentException',
             '$type should be a string and cannot be null or empty'
         );
-        TypeMapper::set(array(), 'EasyRdf\MyTypeClass');
+        TypeMapper::set([], 'EasyRdf\MyTypeClass');
     }
 
     public function testSetClassNull()
@@ -175,14 +172,14 @@ class TypeMapperTest extends TestCase
             'InvalidArgumentException',
             '$class should be a string and cannot be null or empty'
         );
-        TypeMapper::set('rdf:mytype', array());
+        TypeMapper::set('rdf:mytype', []);
     }
 
     public function testDelete()
     {
         $this->assertSame('EasyRdf\MyTypeClass', TypeMapper::get('rdf:mytype'));
         TypeMapper::delete('rdf:mytype');
-        $this->assertSame(null, TypeMapper::get('rdf:mytype'));
+        $this->assertNull(TypeMapper::get('rdf:mytype'));
     }
 
     public function testDeleteTypeNull()
@@ -209,7 +206,7 @@ class TypeMapperTest extends TestCase
             'InvalidArgumentException',
             '$type should be a string and cannot be null or empty'
         );
-        TypeMapper::delete(array());
+        TypeMapper::delete([]);
     }
 
     public function testSetNonExtendingDefaultResourceClass()
@@ -260,7 +257,7 @@ class TypeMapperTest extends TestCase
             'InvalidArgumentException',
             '$class should be a string and cannot be null or empty'
         );
-        TypeMapper::setDefaultResourceClass(array());
+        TypeMapper::setDefaultResourceClass([]);
     }
 
     public function testInstantiate()
@@ -277,9 +274,9 @@ class TypeMapperTest extends TestCase
         $this->assertTrue($joe->myMethod());
 
         $joeFoaf = $graph->resource('http://www.example.com/joe/foaf.rdf');
-        
+
         $this->assertClass('EasyRdf\Resource', $joeFoaf);
-        
+
         TypeMapper::setDefaultResourceClass('EasyRdf\MyTypeClass');
         $graph = new Graph(
             'http://www.example.com/joe/foaf.rdf',

--- a/test/EasyRdf/UtilsTest.php
+++ b/test/EasyRdf/UtilsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EasyRdf;
 
 /**
@@ -31,12 +32,10 @@ namespace EasyRdf;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
-
-require_once dirname(__DIR__).DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(__DIR__).\DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class UtilsTest extends TestCase
 {
@@ -98,32 +97,31 @@ class UtilsTest extends TestCase
 
     public function testIsAssoc()
     {
-        $arr = array('foo' => 'bar');
+        $arr = ['foo' => 'bar'];
         $this->assertTrue(Utils::isAssociativeArray($arr));
-
     }
 
     public function testIsAssocNonArray()
     {
-         $this->assertFalse(Utils::isAssociativeArray('foo'));
+        $this->assertFalse(Utils::isAssociativeArray('foo'));
     }
 
     public function testIsAssocArray()
     {
-        $arr = array('foo', 'bar');
+        $arr = ['foo', 'bar'];
         $this->assertFalse(Utils::isAssociativeArray($arr));
     }
 
     public function testIsAssocIntAppend()
     {
-        $arr = array('foo' => 'bar');
+        $arr = ['foo' => 'bar'];
         array_push($arr, 'rat');
         $this->assertTrue(Utils::isAssociativeArray($arr));
     }
 
     public function testIsAssocIntPreppend()
     {
-        $arr = array('foo' => 'bar');
+        $arr = ['foo' => 'bar'];
         array_unshift($arr, 'rat');
         $this->assertFalse(Utils::isAssociativeArray($arr));
     }
@@ -156,28 +154,28 @@ class UtilsTest extends TestCase
     {
         $res = new Resource('http://www.example.com/');
         $this->assertSame(
-            "http://www.example.com/",
+            'http://www.example.com/',
             Utils::dumpResourceValue($res, 'text')
         );
         $this->assertSame(
             "<a href='http://www.example.com/' ".
             "style='text-decoration:none;color:blue'>".
-            "http://www.example.com/</a>",
+            'http://www.example.com/</a>',
             Utils::dumpResourceValue($res, 'html')
         );
     }
 
     public function testDumpResourceValueFromArray()
     {
-        $res = array('type' => 'uri', 'value' => 'http://www.example.com/');
+        $res = ['type' => 'uri', 'value' => 'http://www.example.com/'];
         $this->assertSame(
-            "http://www.example.com/",
+            'http://www.example.com/',
             Utils::dumpResourceValue($res, 'text')
         );
         $this->assertSame(
             "<a href='http://www.example.com/' ".
             "style='text-decoration:none;color:blue'>".
-            "http://www.example.com/</a>",
+            'http://www.example.com/</a>',
             Utils::dumpResourceValue($res, 'html')
         );
     }
@@ -206,7 +204,7 @@ class UtilsTest extends TestCase
 
     public function testDumpLiteralValue()
     {
-        $literal = new Literal("hello & world");
+        $literal = new Literal('hello & world');
         $this->assertSame(
             '"hello & world"',
             Utils::dumpLiteralValue($literal, 'text')
@@ -219,7 +217,7 @@ class UtilsTest extends TestCase
 
     public function testDumpLiteralValueFromArray()
     {
-        $literal = array('type' => 'literal', 'value' => 'Hot Sauce');
+        $literal = ['type' => 'literal', 'value' => 'Hot Sauce'];
         $this->assertSame(
             '"Hot Sauce"',
             Utils::dumpLiteralValue($literal, 'text')
@@ -245,7 +243,7 @@ class UtilsTest extends TestCase
 
     public function testDumpLiteralValueWithLanguage()
     {
-        $literal = array('type' => 'literal', 'value' => 'Nick', 'lang' => 'en');
+        $literal = ['type' => 'literal', 'value' => 'Nick', 'lang' => 'en'];
         $this->assertSame(
             '"Nick"@en',
             Utils::dumpLiteralValue($literal, 'text')
@@ -258,11 +256,11 @@ class UtilsTest extends TestCase
 
     public function testDumpLiteralValueWithDatatype()
     {
-        $literal = array(
+        $literal = [
             'type' => 'literal',
             'value' => '1',
-            'datatype' => 'http://www.w3.org/2001/XMLSchema#integer'
-        );
+            'datatype' => 'http://www.w3.org/2001/XMLSchema#integer',
+        ];
         $this->assertSame(
             '"1"^^xsd:integer',
             Utils::dumpLiteralValue($literal, 'text')
@@ -275,18 +273,18 @@ class UtilsTest extends TestCase
 
     public function testDumpLiteralValueWithUriDatatype()
     {
-        $literal = array(
+        $literal = [
             'type' => 'literal',
             'value' => '1',
-            'datatype' => 'http://example.com/datatypes/int'
-        );
+            'datatype' => 'http://example.com/datatypes/int',
+        ];
         $this->assertSame(
             '"1"^^<http://example.com/datatypes/int>',
             Utils::dumpLiteralValue($literal, 'text')
         );
         $this->assertSame(
             "<span style='color:black'>&quot;1&quot;^^".
-            "&lt;http://example.com/datatypes/int&gt;</span>",
+            '&lt;http://example.com/datatypes/int&gt;</span>',
             Utils::dumpLiteralValue($literal, 'html')
         );
     }
@@ -351,7 +349,7 @@ class UtilsTest extends TestCase
 
     public function testExecCommandPipeLs()
     {
-        $output = Utils::execCommandPipe('ls', array('/bin/'));
+        $output = Utils::execCommandPipe('ls', ['/bin/']);
         $this->assertContains('cat', explode("\n", $output));
     }
 
@@ -370,7 +368,7 @@ class UtilsTest extends TestCase
     public function testExecCommandPipeCat()
     {
         $output = Utils::execCommandPipe('cat', null, 'Test Message 2');
-        $this->assertSame("Test Message 2", $output);
+        $this->assertSame('Test Message 2', $output);
     }
 
     public function testExecCommandPipeFalse()

--- a/test/FusekiTest.php
+++ b/test/FusekiTest.php
@@ -30,12 +30,10 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
-
-require_once dirname(__FILE__).DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once __DIR__.DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class FusekiTest extends \EasyRdf\TestCase
 {
@@ -48,19 +46,19 @@ class FusekiTest extends \EasyRdf\TestCase
     // Starting up Fuseki is slow - we re-use the same instance for every test
     public static function setUpBeforeClass()
     {
-        $descriptorspec = array(
-            0 => array('pipe', 'r'),
-            1 => array('pipe', 'w'),
-            2 => array('pipe', 'w')
-        );
-    
-        # Start fuseki on a random port number
+        $descriptorspec = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+
+        // Start fuseki on a random port number
         self::$port = rand(10000, 60000);
-        $cmd = "fuseki-server --port=".self::$port." --update --mem /ds";
+        $cmd = 'fuseki-server --port='.self::$port.' --update --mem /ds';
         $dir = sys_get_temp_dir();
         self::$proc = proc_open($cmd, $descriptorspec, $pipes, $dir);
-    
-        # FIXME: timeout
+
+        // FIXME: timeout
         while ($line = fgets($pipes[1])) {
             if (preg_match('/Started (.+) on port (\d+)/', $line, $matches)) {
                 break;
@@ -76,17 +74,17 @@ class FusekiTest extends \EasyRdf\TestCase
         if (self::$proc) {
             // Cause the fuseki server process to terminate
             proc_terminate(self::$proc);
-    
+
             // Close the process resource
             proc_close(self::$proc);
         }
     }
-    
+
     public function setUp()
     {
-        $this->gs = new \EasyRdf\GraphStore("http://localhost:".self::$port."/ds/data");
+        $this->gs = new \EasyRdf\GraphStore('http://localhost:'.self::$port.'/ds/data');
     }
-    
+
     public function testGraphStoreReplace()
     {
         $graph1 = new \EasyRdf\Graph();
@@ -100,11 +98,11 @@ class FusekiTest extends \EasyRdf\TestCase
 
         $graph2 = $this->gs->get('easyrdf-graphstore-test.rdf');
         $this->assertEquals(
-            array(new \EasyRdf\Literal('Test 1')),
+            [new \EasyRdf\Literal('Test 1')],
             $graph2->all('http://example.com/test', 'rdfs:label')
         );
     }
-    
+
     public function testGraphStoreInsert()
     {
         $graph1 = new \EasyRdf\Graph();
@@ -120,14 +118,14 @@ class FusekiTest extends \EasyRdf\TestCase
         $labels = $graph2->all('http://example.com/test', 'rdfs:label');
         sort($labels);
         $this->assertEquals(
-            array(
+            [
                 new \EasyRdf\Literal('Test 2'),
-                new \EasyRdf\Literal('Test 3')
-            ),
+                new \EasyRdf\Literal('Test 3'),
+            ],
             $labels
         );
     }
-    
+
     public function testGraphStoreDelete()
     {
         $graph1 = new \EasyRdf\Graph();

--- a/test/ParserPerformance.php
+++ b/test/ParserPerformance.php
@@ -1,17 +1,17 @@
 <?php
 
-require_once realpath(__DIR__.'/..')."/vendor/autoload.php";
+require_once realpath(__DIR__.'/..').'/vendor/autoload.php';
 
-$parsers = array(
+$parsers = [
     'Arc',
     'Json',
     'Ntriples',
     'RdfXml',
     'Rapper',
     'Turtle',
-);
+];
 
-$documents = array(
+$documents = [
     'foaf.rdf' => 'rdfxml',
     'foaf.ttl' => 'turtle',
     'foaf.nt' => 'ntriples',
@@ -24,24 +24,23 @@ $documents = array(
     'london.ttl' => 'turtle',
     'london.nt' => 'ntriples',
     'london.json' => 'json',
-);
+];
 
 foreach ($documents as $filename => $type) {
-
-    print "Input file: $filename\n";
-    $filepath = dirname(__FILE__) . "/performance/$filename";
+    echo "Input file: $filename\n";
+    $filepath = __DIR__."/performance/$filename";
     if (!file_exists($filepath)) {
-        print "Error: File does not exist.\n";
+        echo "Error: File does not exist.\n";
         continue;
     }
 
     $url = "http://www.example.com/$filename";
     $data = file_get_contents($filepath);
-    print "File size: ".strlen($data)." bytes\n";
+    echo 'File size: '.strlen($data)." bytes\n";
 
     foreach ($parsers as $parser_name) {
         $class = "EasyRdf\\Parser\\{$parser_name}";
-        print "  Parsing using: {$class}\n";
+        echo "  Parsing using: {$class}\n";
 
         try {
             $parser = new $class();
@@ -50,12 +49,12 @@ foreach ($documents as $filename => $type) {
             $start = microtime(true);
             $parser->parse($graph, $data, $type, $url);
             $duration = microtime(true) - $start;
-            print "  Parse time: $duration seconds\n";
-            print "  Triple count: ".$graph->countTriples()."\n";
+            echo "  Parse time: $duration seconds\n";
+            echo '  Triple count: '.$graph->countTriples()."\n";
         } catch (Exception $e) {
-            print 'Parsing failed: '.$e->getMessage()."\n";
+            echo 'Parsing failed: '.$e->getMessage()."\n";
         }
-        print "\n";
+        echo "\n";
 
         unset($graph);
     }

--- a/test/TestHelper.php
+++ b/test/TestHelper.php
@@ -30,7 +30,6 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
@@ -46,18 +45,18 @@ date_default_timezone_set('UTC');
 /*
  * Determine the root, lib, and test directories
  */
-$easyrdfRoot      = realpath(__DIR__ . DIRECTORY_SEPARATOR . '..');
-$easyrdfLibDir    = $easyrdfRoot . DIRECTORY_SEPARATOR . 'lib';
-$easyrdfTestDir   = $easyrdfRoot . DIRECTORY_SEPARATOR . 'test';
+$easyrdfRoot = realpath(__DIR__.DIRECTORY_SEPARATOR.'..');
+$easyrdfLibDir = $easyrdfRoot.DIRECTORY_SEPARATOR.'lib';
+$easyrdfTestDir = $easyrdfRoot.DIRECTORY_SEPARATOR.'test';
 
 /*
  * Prepend the lib and test directories to the  include_path.
  */
-$path = array(
+$path = [
     $easyrdfLibDir,
     $easyrdfTestDir,
-    get_include_path()
-);
+    get_include_path(),
+];
 set_include_path(implode(PATH_SEPARATOR, $path));
 
 /*
@@ -65,10 +64,8 @@ set_include_path(implode(PATH_SEPARATOR, $path));
  */
 unset($easyrdfRoot, $easyrdfLibDir, $easyrdfTestDir, $path);
 
-
 require_once __DIR__.'/EasyRdf/TestCase.php';
 require_once __DIR__.'/EasyRdf/Http/MockClient.php';
-
 
 /**
  * Helper function: get path to a fixture file
@@ -79,7 +76,7 @@ require_once __DIR__.'/EasyRdf/Http/MockClient.php';
  */
 function fixturePath($name)
 {
-    return __DIR__ . DIRECTORY_SEPARATOR . 'fixtures' . DIRECTORY_SEPARATOR . $name;
+    return __DIR__.DIRECTORY_SEPARATOR.'fixtures'.DIRECTORY_SEPARATOR.$name;
 }
 
 /**
@@ -101,13 +98,13 @@ function readFixture($name)
  *
  * @param string $filename the filename to check
  *
- * @return boolean Returns true if the file exists
+ * @return bool Returns true if the file exists
  */
 function requireExists($filename)
 {
     $paths = explode(PATH_SEPARATOR, get_include_path());
     foreach ($paths as $path) {
-        if (substr($path, -1) == DIRECTORY_SEPARATOR) {
+        if (DIRECTORY_SEPARATOR == substr($path, -1)) {
             $fullpath = $path.$filename;
         } else {
             $fullpath = $path.DIRECTORY_SEPARATOR.$filename;
@@ -133,9 +130,10 @@ function requireExists($filename)
  * @param array  $params query string parameters to pass to the script
  *
  * @throws Exception
+ *
  * @return string The resulting webpage (everything printed to STDOUT)
  */
-function executeExample($name, array $params = array())
+function executeExample($name, array $params = [])
 {
     $phpBin = getenv('PHP');
     if (!$phpBin) {
@@ -143,19 +141,19 @@ function executeExample($name, array $params = array())
     }
 
     // We use a wrapper to setup the environment
-    $wrapper = __DIR__ . DIRECTORY_SEPARATOR . 'cli_example_wrapper.php';
+    $wrapper = __DIR__.DIRECTORY_SEPARATOR.'cli_example_wrapper.php';
 
     // Open a pipe to the new PHP process
-    $descriptorspec = array(
-        0 => array("pipe", "r"),
-        1 => array("pipe", "w"),
-        2 => array("pipe", "w")
-    );
+    $descriptorspec = [
+        0 => ['pipe', 'r'],
+        1 => ['pipe', 'w'],
+        2 => ['pipe', 'w'],
+    ];
 
     $process = proc_open(
-        escapeshellcmd($phpBin)." ".
-        escapeshellcmd($wrapper)." ".
-        escapeshellcmd($name)." ".
+        escapeshellcmd($phpBin).' '.
+        escapeshellcmd($wrapper).' '.
+        escapeshellcmd($name).' '.
         escapeshellcmd(http_build_query($params)),
         $descriptorspec,
         $pipes
@@ -176,14 +174,10 @@ function executeExample($name, array $params = array())
         // proc_close in order to avoid a deadlock
         $returnValue = proc_close($process);
         if ($returnValue or $stderr) {
-            throw new Exception(
-                "Failed to run script ($returnValue): ".$stderr.$stdout
-            );
+            throw new Exception("Failed to run script ($returnValue): ".$stderr.$stdout);
         }
     } else {
-        throw new Exception(
-            "Failed to execute new php process: $phpBin"
-        );
+        throw new Exception("Failed to execute new php process: $phpBin");
     }
 
     return $stdout;

--- a/test/cli_example_wrapper.php
+++ b/test/cli_example_wrapper.php
@@ -6,9 +6,9 @@
 // the example on a real web server.
 //
 
-$EXAMPLES_DIR = realpath(dirname(__FILE__) . '/../examples');
+$EXAMPLES_DIR = realpath(__DIR__.'/../examples');
 if (count($argv) <= 1) {
-    print "Error: Missing name of the example to run.\n";
+    echo "Error: Missing name of the example to run.\n";
     exit(-1);
 } else {
     $THIS_SCRIPT = array_shift($argv);
@@ -26,7 +26,7 @@ chdir($EXAMPLES_DIR);
 
 // Check that the example exists
 if (!file_exists($EXAMPLE_FILE)) {
-    print "Error: example does not exist: $EXAMPLE_FILE\n";
+    echo "Error: example does not exist: $EXAMPLE_FILE\n";
     exit(-1);
 }
 

--- a/test/examples/BasicSparqlTest.php
+++ b/test/examples/BasicSparqlTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EasyRdf\Examples;
 
 /**
@@ -31,12 +32,10 @@ namespace EasyRdf\Examples;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
-
-require_once dirname(dirname(__FILE__)).DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(__DIR__).\DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class BasicSparqlTest extends \EasyRdf\TestCase
 {

--- a/test/examples/BasicTest.php
+++ b/test/examples/BasicTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EasyRdf\Examples;
 
 /**
@@ -31,12 +32,10 @@ namespace EasyRdf\Examples;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
-
-require_once dirname(dirname(__FILE__)).DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(__DIR__).\DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class BasicTest extends \EasyRdf\TestCase
 {

--- a/test/examples/ConverterTest.php
+++ b/test/examples/ConverterTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EasyRdf\Examples;
 
 /**
@@ -31,12 +32,10 @@ namespace EasyRdf\Examples;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
-
-require_once dirname(dirname(__FILE__)).DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(__DIR__).\DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class ConverterTest extends \EasyRdf\TestCase
 {
@@ -54,9 +53,8 @@ class ConverterTest extends \EasyRdf\TestCase
     {
         $output = executeExample(
             'converter.php',
-            array(
-                'data' =>
-                    '<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"'.
+            [
+                'data' => '<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"'.
                     '         xmlns:dc="http://purl.org/dc/elements/1.1/">'.
                     ' <rdf:Description rdf:about="http://www.w3.org/">'.
                     '  <dc:title>World Wide Web Consortium</dc:title>'.
@@ -64,8 +62,8 @@ class ConverterTest extends \EasyRdf\TestCase
                     '</rdf:RDF>',
                 'uri' => 'http://example.com/',
                 'input_format' => 'guess',
-                'output_format' => 'ntriples'
-            )
+                'output_format' => 'ntriples',
+            ]
         );
 
         $this->assertContains('<title>EasyRdf Converter</title>', $output);
@@ -82,11 +80,11 @@ class ConverterTest extends \EasyRdf\TestCase
     {
         $output = executeExample(
             'converter.php',
-            array(
+            [
                 'uri' => 'http://www.w3.org/TR/turtle/examples/example1.ttl',
                 'input_format' => 'guess',
-                'output_format' => 'ntriples'
-            )
+                'output_format' => 'ntriples',
+            ]
         );
 
         $this->assertContains('<title>EasyRdf Converter</title>', $output);
@@ -118,16 +116,16 @@ class ConverterTest extends \EasyRdf\TestCase
     {
         $output = executeExample(
             'converter.php',
-            array(
+            [
                 'uri' => 'http://www.w3.org/TR/turtle/examples/example1.ttl',
                 'input_format' => 'guess',
                 'output_format' => 'ntriples',
-                'raw' => 1
-            )
+                'raw' => 1,
+            ]
         );
 
         $this->assertSame(
-            "<http://www.w3.org/TR/rdf-syntax-grammar> <http://purl.org/dc/elements/1.1/title> ".
+            '<http://www.w3.org/TR/rdf-syntax-grammar> <http://purl.org/dc/elements/1.1/title> '.
             "\"RDF/XML Syntax Specification (Revised)\" .\n".
             "<http://www.w3.org/TR/rdf-syntax-grammar> <http://example.org/stuff/1.0/editor> _:genid1 .\n".
             "_:genid1 <http://example.org/stuff/1.0/fullname> \"Dave Beckett\" .\n".

--- a/test/examples/DumpTest.php
+++ b/test/examples/DumpTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EasyRdf\Examples;
 
 /**
@@ -31,12 +32,10 @@ namespace EasyRdf\Examples;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
-
-require_once dirname(dirname(__FILE__)).DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(__DIR__).\DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class DumpTest extends \EasyRdf\TestCase
 {
@@ -51,10 +50,10 @@ class DumpTest extends \EasyRdf\TestCase
     {
         $output = executeExample(
             'dump.php',
-            array(
+            [
                 'uri' => 'http://www.w3.org/2000/10/rdf-tests/rdfcore/amp-in-url/test001.rdf',
-                'format' => 'html'
-            )
+                'format' => 'html',
+            ]
         );
 
         $this->assertContains('<title>EasyRdf Graph Dumper</title>', $output);
@@ -69,10 +68,10 @@ class DumpTest extends \EasyRdf\TestCase
     {
         $output = executeExample(
             'dump.php',
-            array(
+            [
                 'uri' => 'http://www.w3.org/2000/10/rdf-tests/rdfcore/amp-in-url/test001.rdf',
-                'format' => 'text'
-            )
+                'format' => 'text',
+            ]
         );
         $this->assertContains('<title>EasyRdf Graph Dumper</title>', $output);
         $this->assertContains('<h1>EasyRdf Graph Dumper</h1>', $output);

--- a/test/examples/FoafinfoTest.php
+++ b/test/examples/FoafinfoTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EasyRdf\Examples;
 
 /**
@@ -31,12 +32,10 @@ namespace EasyRdf\Examples;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
-
-require_once dirname(dirname(__FILE__)).DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(__DIR__).\DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class FoafinfoTest extends \EasyRdf\TestCase
 {
@@ -55,22 +54,22 @@ class FoafinfoTest extends \EasyRdf\TestCase
     {
         $output = executeExample(
             'foafinfo.php',
-            array('uri' => 'http://njh.me/foaf.rdf')
+            ['uri' => 'http://njh.me/foaf.rdf']
         );
 
         $this->assertContains('<title>EasyRdf FOAF Info Example</title>', $output);
         $this->assertContains('<h1>EasyRdf FOAF Info Example</h1>', $output);
-        $this->assertContains("<dt>Name:</dt><dd>Nicholas J Humfrey</dd>", $output);
+        $this->assertContains('<dt>Name:</dt><dd>Nicholas J Humfrey</dd>', $output);
         $this->assertContains(
-            "<dt>Homepage:</dt><dd><a href=\"http://www.aelius.com/njh/\">http://www.aelius.com/njh/</a></dd>",
+            '<dt>Homepage:</dt><dd><a href="http://www.aelius.com/njh/">http://www.aelius.com/njh/</a></dd>',
             $output
         );
 
-        $this->assertContains("<h2>Known Persons</h2>", $output);
-        $this->assertContains(">Patrick Sinclair</a></li>", $output);
-        $this->assertContains(">Yves Raimond</a></li>", $output);
+        $this->assertContains('<h2>Known Persons</h2>', $output);
+        $this->assertContains('>Patrick Sinclair</a></li>', $output);
+        $this->assertContains('>Yves Raimond</a></li>', $output);
 
-        $this->assertContains("<h2>Interests</h2>", $output);
-        $this->assertContains(">RDF</a></li>", $output);
+        $this->assertContains('<h2>Interests</h2>', $output);
+        $this->assertContains('>RDF</a></li>', $output);
     }
 }

--- a/test/examples/FoafmakerTest.php
+++ b/test/examples/FoafmakerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EasyRdf\Examples;
 
 /**
@@ -31,12 +32,10 @@ namespace EasyRdf\Examples;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
-
-require_once dirname(dirname(__FILE__)).DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(__DIR__).\DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class FoafmakerTest extends \EasyRdf\TestCase
 {
@@ -51,7 +50,7 @@ class FoafmakerTest extends \EasyRdf\TestCase
     {
         $output = executeExample(
             'foafmaker.php',
-            array(
+            [
                 'uri' => 'http://www.example.com/joe#me',
                 'title' => 'Mr',
                 'given_name' => 'Joe',
@@ -63,8 +62,8 @@ class FoafmakerTest extends \EasyRdf\TestCase
                 'person_2' => 'http://www.example.com/alice#me',
                 'person_3' => '',
                 'person_4' => '',
-                'format' => 'turtle'
-            )
+                'format' => 'turtle',
+            ]
         );
 
         $this->assertContains('<title>EasyRdf FOAF Maker Example</title>', $output);
@@ -80,7 +79,7 @@ class FoafmakerTest extends \EasyRdf\TestCase
             "  foaf:givenname &quot;Joe&quot; ;\n".
             "  foaf:family_name &quot;Bloggs&quot; ;\n".
             "  foaf:nick &quot;Joe&quot; ;\n".
-            "  foaf:knows &lt;http://www.example.com/fred#me&gt;,".
+            '  foaf:knows &lt;http://www.example.com/fred#me&gt;,'.
             " &lt;http://www.example.com/alice#me&gt; .\n",
             $output
         );

--- a/test/examples/GraphdirectTest.php
+++ b/test/examples/GraphdirectTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EasyRdf\Examples;
 
 /**
@@ -31,12 +32,10 @@ namespace EasyRdf\Examples;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
-
-require_once dirname(dirname(__FILE__)).DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(__DIR__).\DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class GraphdirectTest extends \EasyRdf\TestCase
 {

--- a/test/examples/HttpgetTest.php
+++ b/test/examples/HttpgetTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EasyRdf\Examples;
 
 /**
@@ -31,12 +32,10 @@ namespace EasyRdf\Examples;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
-
-require_once dirname(dirname(__FILE__)).DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(__DIR__).\DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class HttpgetTest extends \EasyRdf\TestCase
 {
@@ -63,10 +62,10 @@ class HttpgetTest extends \EasyRdf\TestCase
     {
         $output = executeExample(
             'httpget.php',
-            array(
+            [
                 'uri' => 'http://tomheath.com/id/me',
-                'accept' => 'text/html'
-            )
+                'accept' => 'text/html',
+            ]
         );
         $this->assertContains('<title>Test EasyRdf\\HTTP\\Client Get</title>', $output);
         $this->assertContains('<h1>Test EasyRdf\\HTTP\\Client Get</h1>', $output);
@@ -78,10 +77,10 @@ class HttpgetTest extends \EasyRdf\TestCase
     {
         $output = executeExample(
             'httpget.php',
-            array(
+            [
                 'uri' => 'http://tomheath.com/id/me',
-                'accept' => 'application/rdf+xml'
-            )
+                'accept' => 'application/rdf+xml',
+            ]
         );
         $this->assertContains('<title>Test EasyRdf\\HTTP\\Client Get</title>', $output);
         $this->assertContains('<h1>Test EasyRdf\\HTTP\\Client Get</h1>', $output);

--- a/test/examples/ParseRssTest.php
+++ b/test/examples/ParseRssTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EasyRdf\Examples;
 
 /**
@@ -31,12 +32,10 @@ namespace EasyRdf\Examples;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
-
-require_once dirname(dirname(__FILE__)).DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(__DIR__).\DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class ParseRssTest extends \EasyRdf\TestCase
 {
@@ -51,7 +50,7 @@ class ParseRssTest extends \EasyRdf\TestCase
     {
         $output = executeExample(
             'parse_rss.php',
-            array('uri' => 'http://planetrdf.com/index.rdf')
+            ['uri' => 'http://planetrdf.com/index.rdf']
         );
         $this->assertContains(
             '<p>Channel: <a href="http://planetrdf.com/">Planet RDF</a></p>',

--- a/test/examples/SerialiseTest.php
+++ b/test/examples/SerialiseTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EasyRdf\Examples;
 
 /**
@@ -31,12 +32,10 @@ namespace EasyRdf\Examples;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
-
-require_once dirname(dirname(__FILE__)).DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(__DIR__).\DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class SerialiseTest extends \EasyRdf\TestCase
 {
@@ -44,7 +43,7 @@ class SerialiseTest extends \EasyRdf\TestCase
     {
         $output = executeExample(
             'serialise.php',
-            array('format' => 'ntriples')
+            ['format' => 'ntriples']
         );
         $this->assertContains('<title>EasyRdf Serialiser Example</title>', $output);
         $this->assertContains(
@@ -59,7 +58,7 @@ class SerialiseTest extends \EasyRdf\TestCase
     {
         $output = executeExample(
             'serialise.php',
-            array('format' => 'rdfxml')
+            ['format' => 'rdfxml']
         );
         $this->assertContains('<title>EasyRdf Serialiser Example</title>', $output);
         $this->assertContains(
@@ -72,7 +71,7 @@ class SerialiseTest extends \EasyRdf\TestCase
     {
         $output = executeExample(
             'serialise.php',
-            array('format' => 'php')
+            ['format' => 'php']
         );
         $this->assertContains('<title>EasyRdf Serialiser Example</title>', $output);
         $this->assertContains("'value' =&gt; 'http://xmlns.com/foaf/0.1/Person',", $output);

--- a/test/examples/SparqlqueryformTest.php
+++ b/test/examples/SparqlqueryformTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EasyRdf\Examples;
 
 /**
@@ -31,12 +32,10 @@ namespace EasyRdf\Examples;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
-
-require_once dirname(dirname(__FILE__)).DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(__DIR__).\DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class SparqlqueryformTest extends \EasyRdf\TestCase
 {
@@ -52,17 +51,16 @@ class SparqlqueryformTest extends \EasyRdf\TestCase
     {
         $output = executeExample(
             'sparql_queryform.php',
-            array(
+            [
                 'endpoint' => 'http://dbpedia.org/sparql',
-                'query' =>
-                    'PREFIX dbo: <http://dbpedia.org/ontology/>
+                'query' => 'PREFIX dbo: <http://dbpedia.org/ontology/>
                     SELECT * WHERE {
                       ?country rdf:type dbo:Country . 
                       ?country rdfs:label ?label .
                       FILTER ( lang(?label) = "en" )
                     } ORDER BY ?label LIMIT 10',
-                'text' => 1
-            )
+                'text' => 1,
+            ]
         );
 
         $this->assertContains('http://dbpedia.org/resource/10th_century', $output);

--- a/test/examples/UkpostcodeTest.php
+++ b/test/examples/UkpostcodeTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace EasyRdf\Examples;
 
 /**
@@ -31,12 +32,10 @@ namespace EasyRdf\Examples;
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2009-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
-
-require_once dirname(dirname(__FILE__)).DIRECTORY_SEPARATOR.'TestHelper.php';
+require_once \dirname(__DIR__).\DIRECTORY_SEPARATOR.'TestHelper.php';
 
 class UkpostcodeTest extends \EasyRdf\TestCase
 {
@@ -51,7 +50,7 @@ class UkpostcodeTest extends \EasyRdf\TestCase
     {
         $output = executeExample(
             'uk_postcode.php',
-            array('postcode' => 'W1A1AA')
+            ['postcode' => 'W1A1AA']
         );
 
         $this->assertContains('<tr><th>Longitude:</th><td>-0.143799</td></tr>', $output);

--- a/test/fixtures/rdfa/update.php
+++ b/test/fixtures/rdfa/update.php
@@ -3,17 +3,15 @@
 /**
  * Script to update test cases from rdfa.info
  *
- * @package    EasyRdf
  * @copyright  Copyright (c) 2012-2013 Nicholas J Humfrey
  * @license    http://www.opensource.org/licenses/bsd-license.php
  */
-
-require_once realpath(__DIR__.'/../../..')."/vendor/autoload.php";
+require_once realpath(__DIR__.'/../../..').'/vendor/autoload.php';
 
 $RDFA_VERSION = 'rdfa1.1';
 $HOST_LANGUAGE = 'xhtml5';
 $REFERENCE_DISTILLER = 'http://www.w3.org/2012/pyRdfa/extract?format=nt&rdfagraph=output&uri=';
-$FIXTURE_DIR = dirname(__FILE__);
+$FIXTURE_DIR = __DIR__;
 
 \EasyRdf\RdfNamespace::set('test', 'http://www.w3.org/2006/03/test-description#');
 \EasyRdf\RdfNamespace::set('rdfatest', 'http://rdfa.info/vocabs/rdfa-test#');
@@ -28,7 +26,7 @@ foreach ($manifest->allOfType('test:TestCase') as $test) {
     if (!in_array($HOST_LANGUAGE, $test->all('rdfatest:hostLanguage'))) {
         continue;
     }
-    if ($test->get('test:classification')->shorten() != 'test:required') {
+    if ('test:required' != $test->get('test:classification')->shorten()) {
         continue;
     }
 
@@ -36,14 +34,14 @@ foreach ($manifest->allOfType('test:TestCase') as $test) {
     $title = $test->get('dc:title');
     $escapedTitle = addcslashes($title, '\'');
 
-    # Download the test input
+    // Download the test input
     $inputUri = "http://rdfa.info/test-suite/test-cases/$RDFA_VERSION/$HOST_LANGUAGE/$id.xhtml";
     $client->setUri("$inputUri");
     $response = $client->request();
     file_put_contents("$FIXTURE_DIR/$id.xhtml", $response->getBody());
 
-    # Download the expected output
-    $client->setUri($REFERENCE_DISTILLER . urlencode($inputUri));
+    // Download the expected output
+    $client->setUri($REFERENCE_DISTILLER.urlencode($inputUri));
     $response = $client->request();
     $lines = array_filter(preg_split("/[\r\n]+/", $response->getBody()));
     if (count($lines)) {
@@ -53,16 +51,16 @@ foreach ($manifest->allOfType('test:TestCase') as $test) {
     }
     file_put_contents("$FIXTURE_DIR/$id.nt", $data);
 
-    # Output code for PHPUnit
-    print "    public function testCase$id()\n";
-    print "    {\n";
+    // Output code for PHPUnit
+    echo "    public function testCase$id()\n";
+    echo "    {\n";
     if (strlen($title) < 80) {
-        print "        \$this->rdfaTestCase('$id', '$escapedTitle');\n";
+        echo "        \$this->rdfaTestCase('$id', '$escapedTitle');\n";
     } else {
-        print "        \$this->rdfaTestCase(\n";
-        print "            '$id',\n";
-        print "            '$escapedTitle'\n";
-        print "        );\n";
+        echo "        \$this->rdfaTestCase(\n";
+        echo "            '$id',\n";
+        echo "            '$escapedTitle'\n";
+        echo "        );\n";
     }
-    print "    }\n\n";
+    echo "    }\n\n";
 }

--- a/test/testcases/rdfxml-testcases.php
+++ b/test/testcases/rdfxml-testcases.php
@@ -2,9 +2,9 @@
 
 require_once realpath(__DIR__.'/../..').'/vendor/autoload.php';
 
-# Load the manifest
+// Load the manifest
 \EasyRdf\RdfNamespace::set('test', 'http://www.w3.org/2000/10/rdf-tests/rdfcore/testSchema#');
-$manifest = parseTestdata("http://www.w3.org/2000/10/rdf-tests/rdfcore/Manifest.rdf");
+$manifest = parseTestdata('http://www.w3.org/2000/10/rdf-tests/rdfcore/Manifest.rdf');
 
 $passCount = 0;
 $failCount = 0;
@@ -12,48 +12,47 @@ $failCount = 0;
 foreach ($manifest->allOfType('test:PositiveParserTest') as $test) {
     echo "\n\n";
 
-    echo "Input: ".$test->get('test:inputDocument')."\n";
+    echo 'Input: '.$test->get('test:inputDocument')."\n";
     if (!file_exists(testdataFilepath($test->get('test:inputDocument')))) {
         echo "File does not exist.\n";
         continue;
     }
 
-    echo "Output: ".$test->get('test:outputDocument')."\n";
+    echo 'Output: '.$test->get('test:outputDocument')."\n";
     if (!file_exists(testdataFilepath($test->get('test:outputDocument')))) {
         echo "File does not exist.\n";
         continue;
     }
 
-    echo "Status: ".$test->get('test:status')."\n";
-    if ($test->get('test:status') != 'APPROVED') {
+    echo 'Status: '.$test->get('test:status')."\n";
+    if ('APPROVED' != $test->get('test:status')) {
         continue;
     }
 
     $graph = parseTestdata($test->get('test:inputDocument'));
     $out_path = testdataFilepath($test->get('test:outputDocument'));
 
-    $easyrdf_out_path = $out_path . ".easyrdf";
+    $easyrdf_out_path = $out_path.'.easyrdf';
     file_put_contents($easyrdf_out_path, $graph->serialise('ntriples'));
 
     system("rdfdiff -f ntriples -t ntriples $out_path $easyrdf_out_path", $result);
-    if ($result == 0) {
+    if (0 == $result) {
         echo "OK!\n";
-        $passCount++;
+        ++$passCount;
     } else {
         echo "Failed!\n";
-        $failCount++;
+        ++$failCount;
     }
 }
 
 echo "Tests that pass: $passCount\n";
 echo "Tests that fail: $failCount\n";
 
-
 function testdataFilepath($uri)
 {
     return str_replace(
-        "http://www.w3.org/2000/10/rdf-tests/rdfcore/",
-        dirname(__FILE__) . '/rdfxml/',
+        'http://www.w3.org/2000/10/rdf-tests/rdfcore/',
+        __DIR__.'/rdfxml/',
         $uri
     );
 }
@@ -62,5 +61,6 @@ function parseTestdata($uri)
 {
     $filepath = testdataFilepath($uri);
     $data = file_get_contents($filepath);
+
     return new \EasyRdf\Graph("$uri", $data, 'rdfxml');
 }


### PR DESCRIPTION
php-cs-fixer automatically fixes coding-style issues.

This way we can maintain a clean code base without manually check and fix coding styles.